### PR TITLE
MODDATAIMP-92 : Error when uploading file with certain symbols in name

### DIFF
--- a/src/main/java/org/folio/service/storage/LocalFileStorageService.java
+++ b/src/main/java/org/folio/service/storage/LocalFileStorageService.java
@@ -38,7 +38,7 @@ public class LocalFileStorageService extends AbstractFileStorageService {
           vertx.<Void>executeBlocking(b -> {
               try {
                 if (!fs.existsBlocking(path)) {
-                  fs.mkdirsBlocking(path.split(fileDefinition.getName())[0]);
+                  fs.mkdirsBlocking(path.substring(0, path.indexOf(fileDefinition.getName()) - 1));
                 }
                 final Path pathToFile = Paths.get(path);
                 Files.write(pathToFile, data, pathToFile.toFile().exists() ? StandardOpenOption.APPEND : StandardOpenOption.CREATE);

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -97,12 +97,12 @@ public abstract class AbstractRestTest {
   private InitJobExecutionsRsDto jobExecutionCreateSingleFile = new InitJobExecutionsRsDto()
     .withParentJobExecutionId(UUID.randomUUID().toString())
     .withJobExecutions(Collections.singletonList(
-      new JobExecution().withId(UUID.randomUUID().toString()).withSourcePath("CornellFOLIOExemplars_Bibs.mrc")
+      new JobExecution().withId(UUID.randomUUID().toString()).withSourcePath("CornellFOLIOExemplars_Bibs(1).mrc")
     ));
 
   private InitJobExecutionsRsDto jobExecutionCreateMultipleFiles = new InitJobExecutionsRsDto()
     .withParentJobExecutionId(UUID.randomUUID().toString())
-    .withJobExecutions(Arrays.asList(new JobExecution().withId(UUID.randomUUID().toString()).withSourcePath("CornellFOLIOExemplars_Bibs.mrc"),
+    .withJobExecutions(Arrays.asList(new JobExecution().withId(UUID.randomUUID().toString()).withSourcePath("CornellFOLIOExemplars_Bibs(1).mrc"),
       new JobExecution().withId(UUID.randomUUID().toString()).withSourcePath("CornellFOLIOExemplars.mrc")));
 
   @Rule

--- a/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
+++ b/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
@@ -34,8 +34,8 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
   private static final String PROCESS_FILE_IMPORT_PATH = "/processFiles";
 
   private static FileDefinition file1 = new FileDefinition()
-    .withUiKey("CornellFOLIOExemplars_Bibs.mrc.md1547160916680")
-    .withName("CornellFOLIOExemplars_Bibs.mrc")
+    .withUiKey("CornellFOLIOExemplars_Bibs(1).mrc.md1547160916680")
+    .withName("CornellFOLIOExemplars_Bibs(1).mrc")
     .withSize(209);
 
   private static FileDefinition file2 = new FileDefinition()


### PR DESCRIPTION
An error occurs when uploading files with certain symbols in the name. Problematic symbols:  { } [ ] ( ) $ (and probably some other symbols).