### PR TITLE
MODDATAIMP-93 Change validation order for file extension

### DIFF
--- a/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
+++ b/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
@@ -140,7 +140,7 @@ public class FileExtensionServiceImpl implements FileExtensionService {
 
   @Override
   public Future<Boolean> isFileExtensionExistByName(FileExtension fileExtension) {
-    StringBuilder query = new StringBuilder("extension=" + fileExtension.getExtension());
+    StringBuilder query = new StringBuilder("extension=" + fileExtension.getExtension().trim());
     if (fileExtension.getId() != null) {
       query.append("&id!=")
         .append(fileExtension.getId());

--- a/src/test/java/org/folio/rest/FileExtensionAPITest.java
+++ b/src/test/java/org/folio/rest/FileExtensionAPITest.java
@@ -290,7 +290,7 @@ public class FileExtensionAPITest extends AbstractRestTest {
       .post(FILE_EXTENSION_PATH)
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-      .body("errors[0].message", is("fileExtension.duplication.invalid"));
+      .body("errors[0].message", is("fileExtension.extension.invalid"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/FileExtensionAPITest.java
+++ b/src/test/java/org/folio/rest/FileExtensionAPITest.java
@@ -282,6 +282,15 @@ public class FileExtensionAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
       .body("errors[0].message", is("fileExtension.duplication.invalid"));
+
+    RestAssured.given()
+      .spec(spec)
+      .body(fileExtension_4.withExtension(" " + fileExtension_4.getExtension() + " "))
+      .when()
+      .post(FILE_EXTENSION_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+      .body("errors[0].message", is("fileExtension.duplication.invalid"));
   }
 
   @Test


### PR DESCRIPTION
Currently, there are two validations on the backend exist for creating file extensions:
1. Duplicate file extensions
2. Invalid file extension

Now they are executed in the order specified above which may lead to the wrong results.

*Steps to reproduce:*
1. *.csv* file extension already exists on the server. Make POST request to _data-import/fileExtensions_ endpoint with the following body

```
{
  "dataTypes": [],
  "description": "",
  "extension": "  .csv  ",
  "importBlocked": true
}

```
The problem is the *extension* field which has surrounding spaces.

*Expected result:*
The invalid file extension error returns from the server.

```
{
    "errors": [
        {
            "message": "fileExtension.extension.invalid",
            "parameters": []
        }
    ],
    "total_records": 1
}
```


*Actual result:*
The duplication error returns from the server.

```
{
    "errors": [
        {
            "message": "fileExtension.duplication.invalid",
            "parameters": []
        }
    ],
    "total_records": 1
}
```
