### PR TITLE
MODDATAIMP-83 Extend file UploadDefinition checking to verify file extensions.

### DIFF
--- a/src/main/java/org/folio/dao/FileExtensionDao.java
+++ b/src/main/java/org/folio/dao/FileExtensionDao.java
@@ -31,6 +31,14 @@ public interface FileExtensionDao {
   Future<Optional<FileExtension>> getFileExtensionById(String id);
 
   /**
+   * Searches for {@link FileExtension} by its extension
+   *
+   * @param extension File Extension
+   * @return future with optional {@link FileExtension}
+   */
+  Future<Optional<FileExtension>> getFileExtensionByExtenstion(String extension);
+
+  /**
    * Searches for all {@link FileExtension} in database from selected table
    *
    * @return future with {@link FileExtensionCollection}

--- a/src/main/java/org/folio/dao/FileExtensionDaoImpl.java
+++ b/src/main/java/org/folio/dao/FileExtensionDaoImpl.java
@@ -28,6 +28,7 @@ public class FileExtensionDaoImpl implements FileExtensionDao {
   private static final String FILE_EXTENSIONS_TABLE = "file_extensions";
   private static final String DEFAULT_FILE_EXTENSIONS_TABLE = "default_file_extensions";
   private static final String ID_FIELD = "'id'";
+  private static final String EXTENSION_FIELD = "'extension'";
 
   private PostgresClient pgClient;
   private String tenantId;
@@ -69,17 +70,26 @@ public class FileExtensionDaoImpl implements FileExtensionDao {
 
   @Override
   public Future<Optional<FileExtension>> getFileExtensionById(String id) {
+    return getFileExtensionByField(ID_FIELD, id);
+  }
+
+  private Future<Optional<FileExtension>> getFileExtensionByField(String fieldName, String fieldValue) {
     Future<Results<FileExtension>> future = Future.future();
     try {
-      Criteria idCrit = constructCriteria(ID_FIELD, id);
-      pgClient.get(FILE_EXTENSIONS_TABLE, FileExtension.class, new Criterion(idCrit), true, false, future.completer());
+      Criteria crit = constructCriteria(fieldName, fieldValue);
+      pgClient.get(FILE_EXTENSIONS_TABLE, FileExtension.class, new Criterion(crit), true, false, future.completer());
     } catch (Exception e) {
-      LOGGER.error("Error querying FileExtensions by id", e);
+      LOGGER.error("Error querying FileExtensions by {}", fieldName, e);
       future.fail(e);
     }
     return future
       .map(Results::getResults)
       .map(fileExtensions -> fileExtensions.isEmpty() ? Optional.empty() : Optional.of(fileExtensions.get(0)));
+  }
+
+  @Override
+  public Future<Optional<FileExtension>> getFileExtensionByExtenstion(String extension) {
+    return getFileExtensionByField(EXTENSION_FIELD, extension);
   }
 
   @Override

--- a/src/main/java/org/folio/service/fileextension/FileExtensionService.java
+++ b/src/main/java/org/folio/service/fileextension/FileExtensionService.java
@@ -34,6 +34,14 @@ public interface FileExtensionService {
   Future<Optional<FileExtension>> getFileExtensionById(String id);
 
   /**
+   * Searches for {@link FileExtension} by its extension
+   *
+   * @param extension File Extension
+   * @return future with optional {@link FileExtension}
+   */
+  Future<Optional<FileExtension>> getFileExtensionByExtenstion(String extension);
+
+  /**
    * Saves {@link FileExtension}
    *
    * @param fileExtension FileExtension to save

--- a/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
+++ b/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
@@ -44,6 +44,11 @@ public class FileExtensionServiceImpl implements FileExtensionService {
   }
 
   @Override
+  public Future<Optional<FileExtension>> getFileExtensionByExtenstion(String extension) {
+    return fileExtensionDao.getFileExtensionByExtenstion(extension);
+  }
+
+  @Override
   public Future<FileExtension> addFileExtension(FileExtension fileExtension, OkapiConnectionParams params) {
     fileExtension.setId(UUID.randomUUID().toString());
     fileExtension.setDataTypes(sortDataTypes(fileExtension.getDataTypes()));

--- a/src/main/java/org/folio/service/upload/UploadDefinitionService.java
+++ b/src/main/java/org/folio/service/upload/UploadDefinitionService.java
@@ -1,16 +1,14 @@
 package org.folio.service.upload;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import org.folio.dao.UploadDefinitionDaoImpl;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.rest.jaxrs.model.DefinitionCollection;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.rest.jaxrs.model.UploadDefinition;
 
-import javax.ws.rs.core.Response;
 import java.util.Optional;
 
 /**
@@ -92,10 +90,10 @@ public interface UploadDefinitionService {
   /**
    * Validate new UploadDefinition before saving it
    *
-   * @param definition         - object with new upload definition
-   * @param asyncResultHandler - request's result handler
-   * @return - is Upload Definition is valid
+   * @param definition - object with new upload definition
+   * @param -          request's result handler
+   * @return - {@link Errors} object with errors. Valid UploadDefinition if errors count is zero
    */
-  Boolean checkNewUploadDefinition(UploadDefinition definition, Handler<AsyncResult<Response>> asyncResultHandler);
+  Future<Errors> checkNewUploadDefinition(UploadDefinition definition);
 
 }

--- a/src/main/java/org/folio/service/upload/UploadDefinitionServiceImpl.java
+++ b/src/main/java/org/folio/service/upload/UploadDefinitionServiceImpl.java
@@ -217,7 +217,7 @@ public class UploadDefinitionServiceImpl implements UploadDefinitionService {
     for (FileDefinition fileDefinition : definition.getFileDefinitions()) {
       if (fileDefinition.getSize() != null) {
         totalFilesSize += fileDefinition.getSize();
-        if (freeSpace - fileDefinition.getSize() <= 0 && freeSpace - totalFilesSize <= 0) {
+        if (freeSpace - fileDefinition.getSize() <= 0 || freeSpace - totalFilesSize <= 0) {
           errors.getErrors().add(new Error()
             .withMessage(FILE_UPLOAD_ERROR_MESSAGE)
             .withCode(fileDefinition.getName()));

--- a/src/main/java/org/folio/service/upload/UploadDefinitionServiceImpl.java
+++ b/src/main/java/org/folio/service/upload/UploadDefinitionServiceImpl.java
@@ -1,16 +1,13 @@
 package org.folio.service.upload;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import org.apache.commons.io.FileSystemUtils;
 import org.folio.dao.UploadDefinitionDao;
 import org.folio.dao.UploadDefinitionDaoImpl;
 import org.folio.dataimport.util.OkapiConnectionParams;
@@ -26,23 +23,24 @@ import org.folio.rest.jaxrs.model.JobExecutionCollection;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.rest.jaxrs.model.UploadDefinition;
-import org.folio.rest.jaxrs.resource.DataImport;
+import org.folio.service.fileextension.FileExtensionService;
+import org.folio.service.fileextension.FileExtensionServiceImpl;
 import org.folio.service.storage.FileStorageServiceBuilder;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -55,10 +53,12 @@ public class UploadDefinitionServiceImpl implements UploadDefinitionService {
   private static final String JOB_EXECUTION_CREATE_URL = "/change-manager/jobExecutions";
   private static final String JOB_EXECUTION_URL = "/change-manager/jobExecutions";
   private static final String FILE_UPLOAD_ERROR_MESSAGE = "upload.fileSize.invalid";
+  private static final String UPLOAD_FILE_EXTENSION_BLOCKED_ERROR_MESSAGE = "validation.uploadDefinition.fileExtension.blocked";
 
   private Vertx vertx;
   private String tenantId;
   private UploadDefinitionDao uploadDefinitionDao;
+  private FileExtensionService fileExtensionService;
 
   public UploadDefinitionServiceImpl(UploadDefinitionDao uploadDefinitionDao) {
     this.uploadDefinitionDao = uploadDefinitionDao;
@@ -67,7 +67,8 @@ public class UploadDefinitionServiceImpl implements UploadDefinitionService {
   public UploadDefinitionServiceImpl(Vertx vertx, String tenantId) {
     this.vertx = vertx;
     this.tenantId = tenantId;
-    uploadDefinitionDao = new UploadDefinitionDaoImpl(vertx, tenantId);
+    this.uploadDefinitionDao = new UploadDefinitionDaoImpl(vertx, tenantId);
+    this.fileExtensionService = new FileExtensionServiceImpl(vertx, tenantId);
   }
 
   public Future<DefinitionCollection> getUploadDefinitions(String query, int offset, int limit) {
@@ -156,33 +157,75 @@ public class UploadDefinitionServiceImpl implements UploadDefinitionService {
   }
 
   @Override
-  public Boolean checkNewUploadDefinition(UploadDefinition definition, Handler<AsyncResult<Response>> asyncResultHandler) {
-    Set<Error> errorsList = new HashSet<>(definition.getFileDefinitions().size());
-    boolean isValid = validateFreeSpace(definition.getFileDefinitions(), errorsList);
-    if (!isValid) {
-      asyncResultHandler.handle(Future.succeededFuture(DataImport.PostDataImportUploadDefinitionsResponse
-        .respond422WithApplicationJson(new Errors()
-          .withErrors(new ArrayList<>(errorsList))
-          .withTotalRecords(errorsList.size()))));
-    }
-    return isValid;
+  public Future<Errors> checkNewUploadDefinition(UploadDefinition definition) {
+    Errors errors = new Errors()
+      .withTotalRecords(0);
+    return Future.succeededFuture()
+      .map(v -> validateFreeSpace(definition, errors))
+      .compose(errorsReply -> validateFilesExtensionName(definition, errors));
   }
 
-  private boolean validateFreeSpace(List<FileDefinition> fileDefinitions, Collection<Error> errors) {
-    boolean valid = true;
-    for (FileDefinition fileDefinition : fileDefinitions) {
+  private Future<Errors> validateFilesExtensionName(UploadDefinition definition, Errors errors) {
+    List<Future> listOfValidations = new ArrayList<>(definition.getFileDefinitions().size());
+    for (FileDefinition fileDefinition : definition.getFileDefinitions()) {
+      String fileExtension = getFileExtensionFromString(fileDefinition.getName());
+      listOfValidations.add(fileExtensionService.getFileExtensionByExtenstion(fileExtension)
+        .map(extension -> {
+          if (extension.isPresent() && extension.get().getImportBlocked()) {
+            errors.getErrors().add(new Error().withMessage(UPLOAD_FILE_EXTENSION_BLOCKED_ERROR_MESSAGE).withCode(fileDefinition.getName()));
+            errors.setTotalRecords(errors.getTotalRecords() + 1);
+          }
+          return errors;
+        }));
+    }
+    return CompositeFuture.all(listOfValidations)
+      .map(errors);
+  }
+
+  private String getFileExtensionFromString(String fileName) {
+    String extension = "";
+    int i = fileName.lastIndexOf('.');
+    if (i > 0) {
+      extension = fileName.substring(i);
+    }
+    return extension;
+  }
+
+  /**
+   * Calculate free disk space
+   *
+   * @return - free disck space in kbytes
+   */
+  private long getFreeDiskSpaceKb() {
+    long freeSpaceKb = 0L;
+    for (Path root : FileSystems.getDefault().getRootDirectories()) {
       try {
-        if (fileDefinition.getSize() != null && FileSystemUtils.freeSpaceKb() - fileDefinition.getSize() <= 0) { //NOSONAR
-          valid = false;
-          errors.add(new Error()
-            .withMessage(FILE_UPLOAD_ERROR_MESSAGE)
-            .withCode(fileDefinition.getName()));
-        }
+        FileStore store = Files.getFileStore(root);
+        freeSpaceKb += store.getUsableSpace() / 1024;
       } catch (IOException e) {
-        throw new InternalServerErrorException("Error during check file's size");
+        String errorMessage = "Error during check free disk size";
+        logger.error(errorMessage, e);
+        throw new InternalServerErrorException(errorMessage, e);
       }
     }
-    return valid;
+    return freeSpaceKb;
+  }
+
+  private Errors validateFreeSpace(UploadDefinition definition, Errors errors) {
+    long totalFilesSize = 0L;
+    long freeSpace = getFreeDiskSpaceKb();
+    for (FileDefinition fileDefinition : definition.getFileDefinitions()) {
+      if (fileDefinition.getSize() != null) {
+        totalFilesSize += fileDefinition.getSize();
+        if (freeSpace - fileDefinition.getSize() <= 0 && freeSpace - totalFilesSize <= 0) {
+          errors.getErrors().add(new Error()
+            .withMessage(FILE_UPLOAD_ERROR_MESSAGE)
+            .withCode(fileDefinition.getName()));
+          errors.setTotalRecords(errors.getTotalRecords() + 1);
+        }
+      }
+    }
+    return errors;
   }
 
   private Future<UploadDefinition> createJobExecutions(UploadDefinition definition, OkapiConnectionParams params) {

--- a/src/test/java/org/folio/rest/DefaultFileExtensionAPITest.java
+++ b/src/test/java/org/folio/rest/DefaultFileExtensionAPITest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 public class DefaultFileExtensionAPITest extends AbstractRestTest {
 
   private static final String FILE_EXTENSION_PATH = "/data-import/fileExtensions";
-  private static final String FILE_EXTENSION_DEFAULT = FILE_EXTENSION_PATH + "/restore/default";
+  static final String FILE_EXTENSION_DEFAULT = FILE_EXTENSION_PATH + "/restore/default";
 
   @Test
   public void shouldRestoreToDefault() {

--- a/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
+++ b/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
@@ -21,6 +21,7 @@ import org.folio.rest.jaxrs.model.UploadDefinition;
 import org.folio.service.processing.FileProcessor;
 import org.hamcrest.Matchers;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,6 +37,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static org.folio.dataimport.util.RestUtil.OKAPI_TENANT_HEADER;
 import static org.folio.dataimport.util.RestUtil.OKAPI_TOKEN_HEADER;
 import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
+import static org.folio.rest.DefaultFileExtensionAPITest.FILE_EXTENSION_DEFAULT;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertTrue;
@@ -67,6 +69,16 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
     .withName("CornellFOLIOExemplars1.mrc")
     .withSize(Integer.MAX_VALUE);
 
+  private static FileDefinition file5 = new FileDefinition()
+    .withUiKey("CornellFOLIOExemplars.gif.md1547160916680")
+    .withName("CornellFOLIOExemplars.gif")
+    .withSize(209);
+
+  private static FileDefinition file6 = new FileDefinition()
+    .withUiKey("CornellFOLIOExemplars.jpg.md1547160916680")
+    .withName("CornellFOLIOExemplars.jpg")
+    .withSize(209);
+
   private static UploadDefinition uploadDef1 = new UploadDefinition()
     .withFileDefinitions(Collections.singletonList(file1));
 
@@ -82,9 +94,29 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
   private static UploadDefinition uploadDef5 = new UploadDefinition()
     .withFileDefinitions(Arrays.asList(file3, file4));
 
+  private static UploadDefinition uploadDef6 = new UploadDefinition()
+    .withFileDefinitions(Collections.singletonList(file5));
+
+  private static UploadDefinition uploadDef7 = new UploadDefinition()
+    .withFileDefinitions(Arrays.asList(file5, file6));
+
   @After
   public void cleanUpAfterTest() throws IOException {
     FileUtils.deleteDirectory(new File("./storage"));
+  }
+
+  @Before
+  public void before(TestContext context) {
+    Async async = context.async();
+    RestAssured.given()
+      .spec(spec)
+      .when()
+      .post(FILE_EXTENSION_DEFAULT)
+      .then()
+      .log().all()
+      .statusCode(HttpStatus.SC_OK)
+      .body("totalRecords", is(16));
+    async.complete();
   }
 
   @Test
@@ -563,7 +595,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
       .withUserId(UUID.randomUUID().toString());
 
     WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*{36}"), true))
-        .willReturn(WireMock.ok().withBody(JsonObject.mapFrom(jobExecution).encode())));
+      .willReturn(WireMock.ok().withBody(JsonObject.mapFrom(jobExecution).encode())));
 
     String id = RestAssured.given()
       .spec(spec)
@@ -645,7 +677,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void uploadDefinitionCreateServerErrorWhenFailedJobExecutionsCreation () {
+  public void uploadDefinitionCreateServerErrorWhenFailedJobExecutionsCreation() {
     WireMock.stubFor(WireMock.post("/change-manager/jobExecutions")
       .withRequestBody(matchingJsonPath("$[?(@.files.size() == 1)]"))
       .willReturn(WireMock.serverError()));
@@ -690,6 +722,31 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
       .log().all();
+  }
+
+  @Test
+  public void uploadDefinitionCreateValidateFileExtension() {
+    RestAssured.given()
+      .spec(spec)
+      .body(uploadDef6)
+      .when()
+      .post(DEFINITION_PATH)
+      .then()
+      .log().all()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+      .body("errors[0].message", is("validation.uploadDefinition.fileExtension.blocked"))
+      .body("errors[0].code", is(uploadDef6.getFileDefinitions().get(0).getName()))
+      .body("total_records", is(1));
+
+    RestAssured.given()
+      .spec(spec)
+      .body(uploadDef7)
+      .when()
+      .post(DEFINITION_PATH)
+      .then()
+      .log().all()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+      .body("total_records", is(2));
   }
 }
 

--- a/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
+++ b/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
@@ -21,7 +21,6 @@ import org.folio.rest.jaxrs.model.UploadDefinition;
 import org.folio.service.processing.FileProcessor;
 import org.hamcrest.Matchers;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -103,20 +102,6 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
   @After
   public void cleanUpAfterTest() throws IOException {
     FileUtils.deleteDirectory(new File("./storage"));
-  }
-
-  @Before
-  public void before(TestContext context) {
-    Async async = context.async();
-    RestAssured.given()
-      .spec(spec)
-      .when()
-      .post(FILE_EXTENSION_DEFAULT)
-      .then()
-      .log().all()
-      .statusCode(HttpStatus.SC_OK)
-      .body("totalRecords", is(16));
-    async.complete();
   }
 
   @Test
@@ -726,6 +711,15 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
 
   @Test
   public void uploadDefinitionCreateValidateFileExtension() {
+    RestAssured.given()
+      .spec(spec)
+      .when()
+      .post(FILE_EXTENSION_DEFAULT)
+      .then()
+      .log().all()
+      .statusCode(HttpStatus.SC_OK)
+      .body("totalRecords", is(16));
+
     RestAssured.given()
       .spec(spec)
       .body(uploadDef6)


### PR DESCRIPTION
File extensions should be checked during UploadDefinition creation.
If there is a FileExtension with an "importBlocked" == true an error should be returned to the consumer with a message that processing for such a file extension is prohibited.