### PR TITLE
Return error message upon updating file extension `extension` field w…

### DIFF
--- a/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
+++ b/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
@@ -147,7 +147,7 @@ public class FileExtensionServiceImpl implements FileExtensionService {
   public Future<Boolean> isFileExtensionExistByName(FileExtension fileExtension) {
     StringBuilder query = new StringBuilder("extension=" + fileExtension.getExtension().trim());
     if (fileExtension.getId() != null) {
-      query.append("&id!=")
+      query.append(" AND id=\"\" NOT id=")
         .append(fileExtension.getId());
     }
     return fileExtensionDao.getFileExtensions(query.toString(), 0, 1)

--- a/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
+++ b/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
@@ -694,7 +694,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void uploadDefinitionDeleteServerErrorWhenFailedGettingChildrenJobExecutions() {
+  public void uploadDefinitionDeleteServerErrorWhenFailedGettingChildrenJobExecutions(TestContext context) {
     JobExecution jobExecution = new JobExecution()
       .withId("5105b55a-b9a3-4f76-9402-a5243ea63c97")
       .withParentJobId("5105b55a-b9a3-4f76-9402-a5243ea63c95")
@@ -708,6 +708,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
     WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*{36}/children"), true))
       .willReturn(WireMock.serverError()));
 
+    Async async = context.async();
     String id = RestAssured.given()
       .spec(spec)
       .body(uploadDef3)
@@ -716,6 +717,8 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_CREATED)
       .log().all().extract().body().jsonPath().get("id");
+    async.complete();
+    async = context.async();
     RestAssured.given()
       .spec(spec)
       .when()
@@ -723,6 +726,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
       .log().all();
+    async.complete();
   }
 
   @Test


### PR DESCRIPTION
Request URL: http://localhost:9130/data-import/fileExtensions/:id
Request Method: PUT

Current behaviour:
```
{
  "errors" : [ {
    "message" : "duplicate key value violates unique constraint file_extensions_extension_idx_unique",
    "type" : "1",
    "code" : "-1",
    "parameters" : [ {
      "key" : "lower(f_unaccent(jsonb ->> 'extension'::text",
      "value" : ".csv"
    } ]
  } ]
}
```

Expected behavior:

```
{
  "errors" : [ {
    "message" : "fileExtension.duplication.invalid",
    "parameters" : [ ]
  } ],
  "total_records" : 1
}
```


Additionally, check that formatting validation for an _extension_ field is also exists and applies before duplication one.