### PR TITLE
MODDATAIMP-138 - Fix data-import tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-manager-client</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0-SNAPSHOT</version>
       <type>jar</type>
     </dependency>
   </dependencies>
@@ -248,6 +248,18 @@
                 <systemProperty>
                   <key>raml_files</key>
                   <value>${ramlfiles_path}</value>
+                </systemProperty>
+                <systemProperty>
+                  <key>jsonschema2pojo.config.includeToString</key>
+                  <value>true</value>
+                </systemProperty>
+                <systemProperty>
+                  <key>jsonschema2pojo.config.includeHashcodeAndEquals</key>
+                  <value>true</value>
+                </systemProperty>
+                <systemProperty>
+                  <key>jsonschema2pojo.config.useCommonsLang3</key>
+                  <value>true</value>
                 </systemProperty>
               </systemProperties>
             </configuration>

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -212,9 +212,9 @@ public abstract class AbstractRestTest {
         .willReturn(WireMock.created().withBody(JsonObject.mapFrom(jobExecutionCreateMultipleFiles).toString())));
       WireMock.stubFor(WireMock.put(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*"), true))
         .willReturn(WireMock.ok()));
-      WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*{36}"), true))
+      WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.{36}"), true))
         .willReturn(WireMock.ok().withBody(JsonObject.mapFrom(jobExecution).toString())));
-      WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*{36}/children"), true))
+      WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.{36}/children"), true))
         .willReturn(WireMock.ok().withBody(JsonObject.mapFrom(childrenJobExecutions).toString())));
     } catch (UnsupportedEncodingException ignored) {
     }

--- a/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
+++ b/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
@@ -150,7 +150,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
       .withUiStatus(JobExecution.UiStatus.INITIALIZATION)
       .withUserId(UUID.randomUUID().toString());
 
-    WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*{36}"), true))
+    WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.{36}"), true))
       .willReturn(WireMock.ok().withBody(JsonObject.mapFrom(jobExecution).encode())));
 
     uploadDefIdForTest3 = RestAssured.given()
@@ -582,7 +582,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
       .withUserId(UUID.randomUUID().toString());
     async.complete();
     async = context.async();
-    WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*{36}"), true))
+    WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.{36}"), true))
       .willReturn(WireMock.ok().withBody(JsonObject.mapFrom(jobExecution).toString())));
 
     String id = RestAssured.given()
@@ -1014,9 +1014,9 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
       .withUiStatus(JobExecution.UiStatus.INITIALIZATION)
       .withUserId(UUID.randomUUID().toString());
 
-    WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*{36}"), true))
+    WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.{36}"), true))
       .willReturn(WireMock.ok().withBody(JsonObject.mapFrom(jobExecution).encode())));
-    WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*{36}/children"), true))
+    WireMock.stubFor(WireMock.get(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.{36}/children"), true))
       .willReturn(WireMock.serverError()));
 
     Async async = context.async();


### PR DESCRIPTION
* enabled auto-generation hashCode() and equals();
* updated dependency for record-manager-client;
* fixed tests;