### PR TITLE
MODDATAIMP-319: Dom4j XXE vulnerability (CVE-2020-10683)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
       <version>2.8.5</version>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>1.6.1</version>
+      <version>2.1.3</version>
     </dependency>
 
 

--- a/src/main/java/org/folio/service/processing/reader/MarcXmlReader.java
+++ b/src/main/java/org/folio/service/processing/reader/MarcXmlReader.java
@@ -29,7 +29,11 @@ public class MarcXmlReader implements SourceReader {
     this.chunkSize = chunkSize;
     recordsCounter = new MutableInt(0);
     try {
-      this.document = new SAXReader().read(file);
+      // SAXReader.createDefault() prevents XXE attacks by
+      // disabling external DTDs and External Entities
+      // https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10683
+      // https://github.com/dom4j/dom4j/releases/tag/version-2.1.3
+      this.document = SAXReader.createDefault().read(file);
     } catch (DocumentException e) {
       LOGGER.error("Can not read the xml file: %s", e, file);
       throw new RecordsReaderException(e);


### PR DESCRIPTION
Dom4j's SAXReader enables external DTDs and External Entities
by default when reading XML files.

This makes mod-data-import vulnerable to XXE attacks:
https://en.wikipedia.org/wiki/XML_external_entity_attack

Fix this by upgrading to latest Dom4j and disabling external DTDs and
External Entities by changing the SAXReader configuration as suggested on
https://github.com/dom4j/dom4j/releases/tag/version-2.1.3
https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#saxreader

Reference: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10683