### PR TITLE
MODDATIMP-316: Disable CQL2PgJSON & CQLWrapper extra logging in mod-data-import.

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -3,7 +3,7 @@ stages:
   steps:
   - runScriptConfig:
       image: maven:3-adoptopenjdk-11
-      shellScript: mvn package -DskipTests
+      shellScript: mvn package -DskipTests -Djava.util.logging.config.file=vertx-default-jul-logging.properties
 - name: Build Docker with DIND
   steps:
   - publishImageConfig:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2020-10-29 v1.12.0-SNAPSHOT
+* [MODDATAIMP-316](https://issues.folio.org/browse/MODDATAIMP-316) Disable CQL2PgJSON & CQLWrapper extra logging in mod-data-import.
+
 ## 2020-10-14 v1.11.0
 * Add batch-MARC-import script, `scripts/load-marc-data-into-folio.sh`
 * [MODDATAIMP-324](https://issues.folio.org/browse/MODDATAIMP-324) Update all Data-Import modules to the new RMB version

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -288,7 +288,7 @@
     },
     "env": [
       { "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0"
+        "value": "-XX:MaxRAMPercentage=66.0 -Djava.util.logging.config.file=vertx-default-jul-logging.properties"
       },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -14,3 +14,6 @@ logger.folio.appenderRef.stdout.ref = STDOUT
 
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.cql2pgjson.name = org.folio.rest.persist.cql
+logger.cql2pgjson.level = OFF

--- a/src/main/resources/vertx-default-jul-logging.properties
+++ b/src/main/resources/vertx-default-jul-logging.properties
@@ -1,0 +1,5 @@
+handlers = java.util.logging.ConsoleHandler
+.level = ALL
+
+logger.cql2pgjson.level = ERROR
+logger.cql2pgjson.name = org.folio.cql2pgjson.CQL2PgJSON


### PR DESCRIPTION
1. New config file "vertx-default-jul-logging" for overriding vertx-jul added with disabling(except ERROR log-level) CQL2PgJSON.
2. Disabling CQLWrapper to log4j2.properties added.
3. "-Djava.util.logging.config.file=vertx-default-jul-logging.properties" added for ModuleDescriptor.
4. "-Djava.util.logging.config.file=vertx-default-jul-logging.properties" to the .rancher-config-file.
5. NEWS updated.