### PR TITLE
Add PR Template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Purpose
+_Describe the purpose of the pull request. Include background information if necessary._
+
+## Approach
+_How does this change fulfill the purpose?_
+
+#### TODOS and Open Questions
+- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
+
+## Learning
+_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._


### PR DESCRIPTION
## Purpose
Adding default PR template such as what has been used in other FOLIO repos  https://github.com/folio-org/mod-kb-ebsco-java/blob/master/PULL_REQUEST_TEMPLATE.md

## Approach
- added default template

#### TODOS and Open Questions
- [ ] Will add to other Folijet Repos if template format is acceptable
- [ ] Should Jira ticket and update to news.md file be done for all PRs (small update but will add if needed)?

## Learning
https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/using-templates-to-encourage-useful-issues-and-pull-requests