### PR TITLE
Remove unnecessary interface dependency

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -7,10 +7,6 @@
       "version": "1.0"
     },
     {
-      "id": "source-manager-records",
-      "version": "1.0"
-    },
-    {
       "id": "users",
       "version": "15.0"
     }


### PR DESCRIPTION
## Purpose
source-manager-records interface dependency is no longer required by mod-data-import