### PR TITLE
Generate id for RawRecordsDto

### DIFF
--- a/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
+++ b/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
@@ -150,6 +150,7 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
           recordsCounter += records.size();
 
           chunk = new RawRecordsDto()
+            .withId(UUID.randomUUID().toString())
             .withInitialRecords(records)
             .withRecordsMetadata(new RecordsMetadata()
               .withContentType(reader.getContentType())


### PR DESCRIPTION
## Purpose
Ensure exactly once delivery for chunks of records

## Approach
Generate id for the chunk and skip in SRM if that id violates unique constraint

