### PR TITLE
MODDATAIMP-388: Import job is not completed on file parsing error [BUGFIX]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-XX-XX v2.1.0-SNAPSHOT
+* [MODDATAIMP-388](https://issues.folio.org/browse/MODDATAIMP-388) Import job is not completed on file parsing error[BUGFIX]
+
 ## 2021-03-18 v2.0.0
 * [MODDATAIMP-315](https://issues.folio.org/browse/MODDATAIMP-315) Use Kafka for data-import file processing
 * [MODDATAIMP-352](https://issues.folio.org/browse/MODDATAIMP-352) Implement source reader for EDIFACT files.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 2021-XX-XX v2.1.0-SNAPSHOT
+## 2021-XX-XX v2.0.1-SNAPSHOT
 * [MODDATAIMP-388](https://issues.folio.org/browse/MODDATAIMP-388) Import job is not completed on file parsing error[BUGFIX]
 
 ## 2021-03-18 v2.0.0


### PR DESCRIPTION
## Purpose
Data import job is not completed with an error when a file parsing error occurs. Data-import should finishes with status "FAILED".

## Approach
Exception catching added. Moreover, there were changed default current progress number to 0 (was 1). It needs for the status 'FAILED' (Completed with errors without this change)

## Learning
More info: https://issues.folio.org/browse/MODDATAIMP-388
This PR should be merged with: https://github.com/folio-org/mod-source-record-manager/pull/401
