### PR TITLE
MODDATAIMP-400: Resolve data-import catching error issues [BUGFIX]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ## 2021-XX-XX v2.0.1-SNAPSHOT
 * [MODDATAIMP-388](https://issues.folio.org/browse/MODDATAIMP-388) Import job is not completed on file parsing error[BUGFIX]
+* [MODDATAIMP-400](https://issues.folio.org/browse/MODDATAIMP-400) Resolve data-import catching error issues[BUGFIX]
+
 
 ## 2021-03-18 v2.0.0
 * [MODDATAIMP-315](https://issues.folio.org/browse/MODDATAIMP-315) Use Kafka for data-import file processing

--- a/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
+++ b/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
@@ -70,7 +70,6 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
 
   @Override
   public void process(JsonObject jsonRequest, JsonObject jsonParams) { //NOSONAR
-    try {
       ProcessFilesRqDto request = jsonRequest.mapTo(ProcessFilesRqDto.class);
       UploadDefinition uploadDefinition = request.getUploadDefinition();
       JobProfileInfo jobProfile = request.getJobProfileInfo();
@@ -87,10 +86,7 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
             definition -> succeededFuture(definition.withStatus(UploadDefinition.Status.COMPLETED)),
             params.getTenantId());
           return succeededFuture();
-        });
-    } catch (Exception e) {
-      LOGGER.error("Can`t process file. Cause: ", e.getMessage());
-    }
+        }).onFailure(e -> LOGGER.error("Can`t process file. Cause: {}", e.getMessage()));
   }
 
   /**

--- a/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
+++ b/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
@@ -89,7 +89,7 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
           return succeededFuture();
         });
     } catch (Exception e) {
-      LOGGER.error("Can`t process file with this json-request: {}", jsonRequest);
+      LOGGER.error("Can`t process file. Cause: ", e.getMessage());
     }
   }
 

--- a/src/test/java/org/folio/service/processing/ParallelFileChunkingProcessorUnitTest.java
+++ b/src/test/java/org/folio/service/processing/ParallelFileChunkingProcessorUnitTest.java
@@ -63,6 +63,7 @@ public class ParallelFileChunkingProcessorUnitTest {
   private static final String SOURCE_PATH_4 = "src/test/resources/invalidJsonExample.json";
   private static final String SOURCE_PATH_5 = "src/test/resources/UChicago_SampleBibs.xml";
   private static final String SOURCE_PATH_6 = "src/test/resources/invalidUChicago_SampleBibs.xml";
+  private static final String SOURCE_PATH_7 = "src/test/resources/invalidMarcFile.mrc";
 
   private static final int RECORDS_NUMBER = 62;
   private static final int CHUNKS_NUMBER = 2;
@@ -507,6 +508,36 @@ public class ParallelFileChunkingProcessorUnitTest {
 
     FileStorageService fileStorageService = Mockito.mock(FileStorageService.class);
     when(fileStorageService.getFile(anyString())).thenReturn(new File(SOURCE_PATH_6));
+
+    /* when */
+    Future<Void> future = fileProcessor.processFile(fileDefinition, jobProfile, fileStorageService, okapiConnectionParams);
+
+    /* then */
+    future.onComplete(ar -> {
+      assertTrue(ar.failed());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnErrorOnInvalidMrcFile(TestContext context) {
+    /* given */
+    Async async = context.async();
+    String stubSourcePath = StringUtils.EMPTY;
+
+    String jobExecutionId = UUID.randomUUID().toString();
+
+    FileDefinition fileDefinition = new FileDefinition()
+      .withSourcePath(stubSourcePath)
+      .withJobExecutionId(jobExecutionId);
+    JobProfileInfo jobProfile = new JobProfileInfo()
+      .withId(UUID.randomUUID().toString())
+      .withDataType(JobProfileInfo.DataType.MARC)
+      .withName("MARC profile");
+    OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(headers, vertx);
+
+    FileStorageService fileStorageService = Mockito.mock(FileStorageService.class);
+    when(fileStorageService.getFile(anyString())).thenReturn(new File(SOURCE_PATH_7));
 
     /* when */
     Future<Void> future = fileProcessor.processFile(fileDefinition, jobProfile, fileStorageService, okapiConnectionParams);

--- a/src/test/resources/invalidMarcFile.mrc
+++ b/src/test/resources/invalidMarcFile.mrc
@@ -1,0 +1,1 @@
+invalid marc file


### PR DESCRIPTION
## Purpose
Job with empty or invalid marc file stucks with invalid (NaN%) progress number. It can be removed.
The main goal - to fix it.


## Approach
If there are no records or invalid MARC-content (just simple text, for example), then data-import will be finished with Failed status. The job won`t be stuck.

Moreover, added try/catch to the highest level for logging different errors.

## Learning
More info: https://issues.folio.org/browse/MODDATAIMP-400
