### PR TITLE
MODSOURMAN-412 Restructure MARC related events to have common and type specific ones

### DIFF
--- a/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
+++ b/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
@@ -37,7 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static io.vertx.core.Future.succeededFuture;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_MARC_BIB_RECORDS_CHUNK_READ;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_READ;
 import static org.folio.rest.jaxrs.model.StatusDto.ErrorStatus.FILE_PROCESSING_ERROR;
 import static org.folio.rest.jaxrs.model.StatusDto.Status.ERROR;
 
@@ -134,7 +134,7 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
 
     String topicName = KafkaTopicNameHelper.formatTopicName(kafkaConfig.getEnvId(),
       KafkaTopicNameHelper.getDefaultNameSpace(), params.getTenantId(),
-      DI_RAW_MARC_BIB_RECORDS_CHUNK_READ.value());
+      DI_RAW_RECORDS_CHUNK_READ.value());
 
     File file = fileStorageService.getFile(fileDefinition.getSourcePath());
 
@@ -159,7 +159,7 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
 
     LOGGER.debug("About to start piping to KafkaProducer... jobProfile: {}", jobProfile);
     KafkaProducer<String, String> producer = KafkaProducer.createShared(vertx,
-      DI_RAW_MARC_BIB_RECORDS_CHUNK_READ + "_Producer", kafkaConfig.getProducerProps());
+      DI_RAW_RECORDS_CHUNK_READ + "_Producer", kafkaConfig.getProducerProps());
     readStreamWrapper.pipeTo(new WriteStreamWrapper(producer), ar -> {
       boolean succeeded = ar.succeeded();
       LOGGER.debug("Data piping has been completed. ar.succeeded(): {} jobProfile: {}",succeeded, jobProfile);

--- a/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
+++ b/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_MARC_BIB_RECORDS_CHUNK_READ;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_READ;
 
 public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRecord<String, String>> {
   private static final Logger LOGGER = LogManager.getLogger();
@@ -182,7 +182,7 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
     String correlationId = UUID.randomUUID().toString();
     Event event = new Event()
       .withId(correlationId)
-      .withEventType(DI_RAW_MARC_BIB_RECORDS_CHUNK_READ.value())
+      .withEventType(DI_RAW_RECORDS_CHUNK_READ.value())
       .withEventPayload(ZIPArchiver.zip(Json.encode(chunk)))
       .withEventMetadata(new EventMetadata()
         .withTenantId(tenantId)


### PR DESCRIPTION
## Purpose
To provide more common naming for events

## Approach
* changed event from `DI_RAW_MARC_BIB_RECORDS_CHUNK_READ` to more common - `DI_RAW_RECORDS_CHUNK_READ`

## Learning
[MODSOURMAN-412](https://issues.folio.org/browse/MODSOURMAN-412)
