### PR TITLE
MODDATAIMP-413 - When a file is uploaded for data import, the file extension check should be case-INsensitive

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
-## 2021-XX-XX v2.0.1-SNAPSHOT
-* [MODDATAIMP-388](https://issues.folio.org/browse/MODDATAIMP-388) Import job is not completed on file parsing error[BUGFIX]
-* [MODDATAIMP-400](https://issues.folio.org/browse/MODDATAIMP-400) Resolve data-import catching error issues[BUGFIX]
+## 2021-XX-XX v2.0.2-SNAPSHOT
+* [MODDATAIMP-413](https://issues.folio.org/browse/MODDATAIMP-413) When a file is uploaded for data import, the file extension check should be case-insensitive
+
+## 2021-04-09 v2.0.1
+* [MODDATAIMP-388](https://issues.folio.org/browse/MODDATAIMP-388) Import job is not completed on file parsing error
+* [MODDATAIMP-400](https://issues.folio.org/browse/MODDATAIMP-400) Resolve data-import catching error issues
 
 
 ## 2021-03-18 v2.0.0

--- a/src/main/java/org/folio/dao/FileExtensionDao.java
+++ b/src/main/java/org/folio/dao/FileExtensionDao.java
@@ -40,7 +40,7 @@ public interface FileExtensionDao {
    * @param tenantId  tenant id tenant id
    * @return future with optional {@link FileExtension}
    */
-  Future<Optional<FileExtension>> getFileExtensionByExtenstion(String extension, String tenantId);
+  Future<Optional<FileExtension>> getFileExtensionByExtension(String extension, String tenantId);
 
   /**
    * Searches for all {@link FileExtension} in database from selected table

--- a/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
+++ b/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
@@ -61,7 +61,7 @@ public class FileExtensionServiceImpl implements FileExtensionService {
 
   @Override
   public Future<Optional<FileExtension>> getFileExtensionByExtenstion(String extension, String tenantId) {
-    return fileExtensionDao.getFileExtensionByExtenstion(extension, tenantId);
+    return fileExtensionDao.getFileExtensionByExtension(extension, tenantId);
   }
 
   @Override

--- a/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
+++ b/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
@@ -86,8 +86,8 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
     .withSize(Integer.MAX_VALUE);
 
   private static FileDefinition file5 = new FileDefinition()
-    .withUiKey("CornellFOLIOExemplars.gif.md1547160916680")
-    .withName("CornellFOLIOExemplars.gif")
+    .withUiKey("CornellFOLIOExemplars.GIF.md1547160916680")
+    .withName("CornellFOLIOExemplars.GIF")
     .withSize(209);
 
   private static FileDefinition file6 = new FileDefinition()


### PR DESCRIPTION
## Purpose
When a file is uploaded for data import, the file extension check should be case-insensitive

## Approach
* cqlWrapper is used to build case insensitive query for file extension


## Learning
[MODDATAIMP-413](https://issues.folio.org/browse/MODDATAIMP-413)