### PR TITLE
MODDATAIMP-464 Change dataType to have have common type for MARC related subtypes

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -9,18 +9,18 @@ stages:
   - publishImageConfig:
       dockerfilePath: ./Dockerfile
       buildContext: .
-      tag: docker.dev.folio.org/mod-data-import:spitfire-${CICD_EXECUTION_SEQUENCE}
+      tag: docker.dev.folio.org/mod-data-import:folijet-${CICD_EXECUTION_SEQUENCE}
       pushRemote: true
       registry: docker.dev.folio.org
 - name: Deploy
   steps:
   - applyAppConfig:
-      catalogTemplate: p-htqfq:spitfire-helmcharts-mod-data-import
+      catalogTemplate: p-gh7sb:folijet-helmcharts-mod-data-import
       version: 0.1.32
       answers:
         image.repository: docker.dev.folio.org/mod-data-import
-        image.tag: spitfire-${CICD_EXECUTION_SEQUENCE}
-      targetNamespace: spitfire
+        image.tag: folijet-${CICD_EXECUTION_SEQUENCE}
+      targetNamespace: folijet
       name: mod-data-import
 timeout: 60
 notification: {}

--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -9,18 +9,18 @@ stages:
   - publishImageConfig:
       dockerfilePath: ./Dockerfile
       buildContext: .
-      tag: docker.dev.folio.org/mod-data-import:folijet-${CICD_EXECUTION_SEQUENCE}
+      tag: docker.dev.folio.org/mod-data-import:spitfire-${CICD_EXECUTION_SEQUENCE}
       pushRemote: true
       registry: docker.dev.folio.org
 - name: Deploy
   steps:
   - applyAppConfig:
-      catalogTemplate: p-gh7sb:folijet-helmcharts-mod-data-import
+      catalogTemplate: p-htqfq:spitfire-helmcharts-mod-data-import
       version: 0.1.32
       answers:
         image.repository: docker.dev.folio.org/mod-data-import
-        image.tag: folijet-${CICD_EXECUTION_SEQUENCE}
-      targetNamespace: folijet
+        image.tag: spitfire-${CICD_EXECUTION_SEQUENCE}
+      targetNamespace: spitfire
       name: mod-data-import
 timeout: 60
 notification: {}

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.1.1</version>
+      <version>3.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
@@ -204,7 +204,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-manager-client</artifactId>
-      <version>3.1.0</version>
+      <version>3.2.0-SNAPSHOT</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/service/processing/reader/SourceReaderBuilder.java
+++ b/src/main/java/org/folio/service/processing/reader/SourceReaderBuilder.java
@@ -50,8 +50,5 @@ public class SourceReaderBuilder {
   }
 
   private static boolean isMarc(JobProfileInfo jobProfile) {
-    return jobProfile != null && (jobProfile.getDataType() == DataType.MARC_BIB ||
-      jobProfile.getDataType() == DataType.MARC_AUTHORITY ||
-      jobProfile.getDataType() == DataType.MARC_HOLDING);
-  }
+    return jobProfile != null && jobProfile.getDataType() == JobProfileInfo.DataType.MARC;  }
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -69,6 +69,11 @@
       "run": "after",
       "snippetPath": "update_file_extensions.sql",
       "fromModuleVersion": "mod-data-import-2.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "update_data_type_for_file_extensions.sql",
+      "fromModuleVersion": "mod-data-import-2.2.0"
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/update_data_type_for_file_extensions.sql
+++ b/src/main/resources/templates/db_scripts/update_data_type_for_file_extensions.sql
@@ -1,0 +1,19 @@
+-- default_file_extensions:
+-- change values: from MARC_HOLDING to MARC, remove MARC_AUTHORITY and MARC_BIB
+UPDATE ${myuniversity}_${mymodule}.default_file_extensions
+SET jsonb = regexp_replace(jsonb::text, '\"MARC_BIB\",', '', 'g')::jsonb
+WHERE id IN ('5cf7a0e5-f359-43f5-8c96-e5df74131183','1df36889-4d3a-482e-a8c8-9c67b8245feb',
+             'f445092c-94b8-408a-a9f1-5edd8b5919c9','8ffe5abc-a532-48cb-ab0e-827ea980154c',
+             '6cf5568b-4d37-4d35-9116-e8a52120779d');
+
+UPDATE ${myuniversity}_${mymodule}.default_file_extensions
+SET jsonb = regexp_replace(jsonb::text, '\"MARC_AUTHORITY\",', '', 'g')::jsonb
+WHERE id IN ('5cf7a0e5-f359-43f5-8c96-e5df74131183','1df36889-4d3a-482e-a8c8-9c67b8245feb',
+             'f445092c-94b8-408a-a9f1-5edd8b5919c9','8ffe5abc-a532-48cb-ab0e-827ea980154c',
+             '6cf5568b-4d37-4d35-9116-e8a52120779d');
+
+UPDATE ${myuniversity}_${mymodule}.default_file_extensions
+SET jsonb = regexp_replace(jsonb::text, '\"MARC_HOLDING\"', '"MARC"', 'g')::jsonb
+WHERE id IN ('5cf7a0e5-f359-43f5-8c96-e5df74131183','1df36889-4d3a-482e-a8c8-9c67b8245feb',
+             'f445092c-94b8-408a-a9f1-5edd8b5919c9','8ffe5abc-a532-48cb-ab0e-827ea980154c',
+             '6cf5568b-4d37-4d35-9116-e8a52120779d');

--- a/src/main/resources/templates/db_scripts/update_data_type_for_file_extensions.sql
+++ b/src/main/resources/templates/db_scripts/update_data_type_for_file_extensions.sql
@@ -17,3 +17,13 @@ SET jsonb = regexp_replace(jsonb::text, '\"MARC_HOLDING\"', '"MARC"', 'g')::json
 WHERE id IN ('5cf7a0e5-f359-43f5-8c96-e5df74131183','1df36889-4d3a-482e-a8c8-9c67b8245feb',
              'f445092c-94b8-408a-a9f1-5edd8b5919c9','8ffe5abc-a532-48cb-ab0e-827ea980154c',
              '6cf5568b-4d37-4d35-9116-e8a52120779d');
+
+
+UPDATE ${myuniversity}_${mymodule}.file_extensions
+SET jsonb = regexp_replace(jsonb::text, '\"MARC_BIB\",', '', 'g')::jsonb;
+
+UPDATE ${myuniversity}_${mymodule}.file_extensions
+SET jsonb = regexp_replace(jsonb::text, '\"MARC_AUTHORITY\",', '', 'g')::jsonb;
+
+UPDATE ${myuniversity}_${mymodule}.file_extensions
+SET jsonb = regexp_replace(jsonb::text, '\"MARC_HOLDING\"', '"MARC"', 'g')::jsonb;

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -85,7 +85,7 @@ public abstract class AbstractRestTest {
     .withSourcePath("CornellFOLIOExemplars_Bibs.mrc")
     .withJobProfileInfo(new JobProfileInfo()
       .withName("Marc jobs profile")
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withId(UUID.randomUUID().toString()))
     .withUserId(UUID.randomUUID().toString());
 

--- a/src/test/java/org/folio/rest/FileExtensionAPITest.java
+++ b/src/test/java/org/folio/rest/FileExtensionAPITest.java
@@ -32,7 +32,7 @@ public class FileExtensionAPITest extends AbstractRestTest {
 
   private static FileExtension fileExtension_1 = new FileExtension()
     .withExtension(".marc")
-    .withDataTypes(Collections.singletonList(DataType.MARC_BIB))
+    .withDataTypes(Collections.singletonList(DataType.MARC))
     .withImportBlocked(false);
   private static FileExtension fileExtension_2 = new FileExtension()
     .withExtension(".edi")

--- a/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
+++ b/src/test/java/org/folio/rest/UploadDefinitionAPITest.java
@@ -640,7 +640,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
       .withJobProfileInfo(new JobProfileInfo()
         .withName("Marc jobs profile")
         .withId(UUID.randomUUID().toString())
-        .withDataType(JobProfileInfo.DataType.MARC_BIB))
+        .withDataType(JobProfileInfo.DataType.MARC))
       .withUserId(UUID.randomUUID().toString());
     async.complete();
     async = context.async();
@@ -758,7 +758,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
     JobProfileInfo jobProf = new JobProfileInfo();
     jobProf.setId(UUID.randomUUID().toString());
     jobProf.setName(StringUtils.EMPTY);
-    jobProf.setDataType(JobProfileInfo.DataType.MARC_BIB);
+    jobProf.setDataType(JobProfileInfo.DataType.MARC);
 
     ProcessFilesRqDto processFilesReqDto = new ProcessFilesRqDto()
       .withUploadDefinition(uploadDef)
@@ -786,7 +786,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
     JobProfileInfo jobProfile = new JobProfileInfo();
     jobProfile.setId(UUID.randomUUID().toString());
     jobProfile.setName(StringUtils.EMPTY);
-    jobProfile.setDataType(JobProfileInfo.DataType.MARC_BIB);
+    jobProfile.setDataType(JobProfileInfo.DataType.MARC);
     ProcessFilesRqDto processFilesRqDto = new ProcessFilesRqDto()
       .withUploadDefinition(uploadDefinition)
       .withJobProfileInfo(jobProfile);
@@ -825,7 +825,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
     JobProfileInfo jobProf = new JobProfileInfo();
     jobProf.setId(UUID.randomUUID().toString());
     jobProf.setName(StringUtils.EMPTY);
-    jobProf.setDataType(JobProfileInfo.DataType.MARC_BIB);
+    jobProf.setDataType(JobProfileInfo.DataType.MARC);
 
     ProcessFilesRqDto processFilesReqDto = new ProcessFilesRqDto()
       .withUploadDefinition(uploadDef)
@@ -853,7 +853,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
     JobProfileInfo jobProfile = new JobProfileInfo();
     jobProfile.setId(UUID.randomUUID().toString());
     jobProfile.setName(StringUtils.EMPTY);
-    jobProfile.setDataType(JobProfileInfo.DataType.MARC_BIB);
+    jobProfile.setDataType(JobProfileInfo.DataType.MARC);
     ProcessFilesRqDto processFilesRqDto = new ProcessFilesRqDto()
       .withUploadDefinition(uploadDefinition)
       .withJobProfileInfo(jobProfile);
@@ -886,7 +886,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
     JobProfileInfo jobProfile = new JobProfileInfo();
     jobProfile.setId(UUID.randomUUID().toString());
     jobProfile.setName(StringUtils.EMPTY);
-    jobProfile.setDataType(JobProfileInfo.DataType.MARC_BIB);
+    jobProfile.setDataType(JobProfileInfo.DataType.MARC);
 
     ProcessFilesRqDto request = new ProcessFilesRqDto()
       .withUploadDefinition(uploadDefinition)
@@ -940,7 +940,7 @@ public class UploadDefinitionAPITest extends AbstractRestTest {
       .withStatus(UploadDefinition.Status.IN_PROGRESS);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB);
+      .withDataType(JobProfileInfo.DataType.MARC);
     ProcessFilesRqDto processFilesRqDto = new ProcessFilesRqDto()
       .withUploadDefinition(uploadDefinition)
       .withJobProfileInfo(jobProfile);

--- a/src/test/java/org/folio/service/processing/ParallelFileChunkingProcessorUnitTest.java
+++ b/src/test/java/org/folio/service/processing/ParallelFileChunkingProcessorUnitTest.java
@@ -91,17 +91,7 @@ public class ParallelFileChunkingProcessorUnitTest {
 
   @Test
   public void shouldReadMarcBibAndSendAllChunks(TestContext context) {
-    readAndSendAllChunks(context, DataType.MARC_BIB);
-  }
-
-  @Test
-  public void shouldReadMarcAuthorityAndSendAllChunks(TestContext context) {
-    readAndSendAllChunks(context, DataType.MARC_AUTHORITY);
-  }
-
-  @Test
-  public void shouldReadMarcHoldingAndSendAllChunks(TestContext context) {
-    readAndSendAllChunks(context, DataType.MARC_HOLDING);
+    readAndSendAllChunks(context, DataType.MARC);
   }
 
   private void readAndSendAllChunks(TestContext context, DataType marcAuthority) {
@@ -164,7 +154,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(headers, vertx);
     FileStorageService fileStorageService = Mockito.mock(FileStorageService.class);
@@ -212,7 +202,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     FileStorageService fileStorageService = Mockito.mock(FileStorageService.class);
     when(fileStorageService.getFile(anyString())).thenReturn(new File(SOURCE_PATH));
@@ -237,7 +227,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     /* when */
     Future<Void> future = fileProcessor.processFile(fileDefinition, jobProfile, null, null);
@@ -263,7 +253,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(headers, vertx);
 
@@ -295,7 +285,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(headers, vertx);
 
@@ -390,7 +380,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(headers, vertx);
 
@@ -439,7 +429,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(headers, vertx);
 
@@ -469,7 +459,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(headers, vertx);
 
@@ -518,7 +508,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(headers, vertx);
 
@@ -548,7 +538,7 @@ public class ParallelFileChunkingProcessorUnitTest {
       .withJobExecutionId(jobExecutionId);
     JobProfileInfo jobProfile = new JobProfileInfo()
       .withId(UUID.randomUUID().toString())
-      .withDataType(JobProfileInfo.DataType.MARC_BIB)
+      .withDataType(JobProfileInfo.DataType.MARC)
       .withName("MARC profile");
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(headers, vertx);
 


### PR DESCRIPTION
## Purpose
Change record type MARC_BIB for more common type MARC, remove MARC_AUTHORITY and MARC_HOLDING from dataTypes

## Approach
- changed data type from MARC to MARC_BIB
- created migration script for removing MARC_AUTHORITY, MARC_HOLDING and changing MARC_BIB to MARC

## Learning
[MODDATAIMP-464](https://issues.folio.org/browse/MODDATAIMP-464)

