### PR TITLE
MODSOURCE-286 - Add permission for retrieving mapping rules and params

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -123,6 +123,7 @@
           "modulePermissions": [
             "change-manager.jobexecutions.get",
             "change-manager.jobexecutions.put",
+            "mapping-metadata.get",
             "source-storage.snapshots.get",
             "source-storage.snapshots.put",
             "users.collection.get",


### PR DESCRIPTION
## Purpose
since mapping metadata (mapping rules and parameters) should be deleted from the data-import payload it is  necessary to provide permission for modules participating in data-import to retrieve mapping metadata

## Learning
[MODSOURCE-286](https://issues.folio.org/browse/MODSOURCE-286)