### PR TITLE
MODDATAIMP-480 Suppress harmless errors from Data Import logs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 2021-08-25 v2.2.0
 * [MODSOURMAN-550](https://issues.folio.org/browse/MODSOURMAN-550) Reduce BE response payload for DI Landing Page to increase performance
-
+* [MODDATAIMP-480](https://issues.folio.org/browse/MODDATAIMP-480) Suppress harmless errors from Data Import logs
 ## 2021-07-30 v2.1.0
 * [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages
 * [MODDATAIMP-511](https://issues.folio.org/browse/MODDATAIMP-511) Upgrade to RAML Module Builder 33.x

--- a/src/main/java/org/folio/service/storage/LocalFileStorageService.java
+++ b/src/main/java/org/folio/service/storage/LocalFileStorageService.java
@@ -72,7 +72,14 @@ public class LocalFileStorageService extends AbstractFileStorageService {
   public Future<Boolean> deleteFile(FileDefinition fileDefinition) {
     Promise<Boolean> promise = Promise.promise();
     try {
-      fs.deleteBlocking(fileDefinition.getSourcePath());
+      String filePath = fileDefinition.getSourcePath();
+      fs.exists(filePath, existResult -> {
+        if (existResult.succeeded() && existResult.result()) {
+          fs.deleteBlocking(filePath);
+        } else if (existResult.failed()) {
+          LOGGER.warn("Couldn't detect the file with id {} in the storage: ", fileDefinition.getId(), existResult.cause());
+        }
+      });
       promise.complete(true);
     } catch (Exception e) {
       LOGGER.error("Couldn't delete the file with id {} from the storage", fileDefinition.getId(), e);

--- a/src/main/java/org/folio/service/storage/LocalFileStorageService.java
+++ b/src/main/java/org/folio/service/storage/LocalFileStorageService.java
@@ -73,14 +73,13 @@ public class LocalFileStorageService extends AbstractFileStorageService {
     Promise<Boolean> promise = Promise.promise();
     try {
       String filePath = fileDefinition.getSourcePath();
-      fs.exists(filePath, existResult -> {
-        if (existResult.succeeded() && existResult.result()) {
-          fs.deleteBlocking(filePath);
-        } else if (existResult.failed()) {
-          LOGGER.warn("Couldn't detect the file with id {} in the storage: ", fileDefinition.getId(), existResult.cause());
-        }
-      });
-      promise.complete(true);
+      if (fs.existsBlocking(filePath)) {
+        fs.deleteBlocking(filePath);
+        promise.complete(true);
+      } else {
+        LOGGER.warn("Couldn't detect the file with id {} in the storage: ", fileDefinition.getId());
+        promise.complete(false);
+      }
     } catch (Exception e) {
       LOGGER.error("Couldn't delete the file with id {} from the storage", fileDefinition.getId(), e);
       promise.complete(false);

--- a/src/main/java/org/folio/service/storage/LocalFileStorageService.java
+++ b/src/main/java/org/folio/service/storage/LocalFileStorageService.java
@@ -77,7 +77,7 @@ public class LocalFileStorageService extends AbstractFileStorageService {
         fs.deleteBlocking(filePath);
         promise.complete(true);
       } else {
-        LOGGER.warn("Couldn't detect the file with id {} in the storage: ", fileDefinition.getId());
+        LOGGER.warn("Couldn't detect the file with id {} in the storage", fileDefinition.getId());
         promise.complete(false);
       }
     } catch (Exception e) {


### PR DESCRIPTION
## Purpose
Harmless errors for data import show up in the logs as clutter, which makes debugging more difficult.

## Learning 
[https://issues.folio.org/browse/MODDATAIMP-480](url)