### PR TITLE
MODDATAIMP-548 - Provide system properties to set chunk size for each marc record format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## 2021-08-25 v2.2.0
 * [MODSOURMAN-550](https://issues.folio.org/browse/MODSOURMAN-550) Reduce BE response payload for DI Landing Page to increase performance
 * [MODDATAIMP-480](https://issues.folio.org/browse/MODDATAIMP-480) Suppress harmless errors from Data Import logs
+* [MODDATAIMP-548](https://issues.folio.org/browse/MODDATAIMP-548) Provide system properties to set records chunk size for each record type and marc format
+
 ## 2021-07-30 v2.1.0
 * [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages
 * [MODDATAIMP-511](https://issues.folio.org/browse/MODDATAIMP-511) Upgrade to RAML Module Builder 33.x

--- a/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
+++ b/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
@@ -183,7 +183,7 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
     Event event = new Event()
       .withId(correlationId)
       .withEventType(DI_RAW_RECORDS_CHUNK_READ.value())
-      .withEventPayload(ZIPArchiver.zip(Json.encode(chunk)))
+      .withEventPayload(Json.encode(chunk))
       .withEventMetadata(new EventMetadata()
         .withTenantId(tenantId)
         .withEventTTL(1)

--- a/src/main/java/org/folio/service/processing/reader/SourceReaderBuilder.java
+++ b/src/main/java/org/folio/service/processing/reader/SourceReaderBuilder.java
@@ -2,12 +2,10 @@ package org.folio.service.processing.reader;
 
 import org.apache.commons.io.FilenameUtils;
 import org.folio.rest.jaxrs.model.JobProfileInfo;
-import org.folio.rest.jaxrs.model.JobProfileInfo.DataType;
 
 import java.io.File;
 
 import static java.util.Optional.ofNullable;
-import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 import static org.folio.service.processing.reader.EdifactReader.EDIFACT_EDI_EXTENSION;
 import static org.folio.service.processing.reader.EdifactReader.EDIFACT_INV_EXTENSION;
 import static org.folio.service.processing.reader.MarcJsonReader.JSON_EXTENSION;
@@ -18,9 +16,14 @@ import static org.folio.service.processing.reader.MarcXmlReader.XML_EXTENSION;
  */
 public class SourceReaderBuilder {
 
-  private static final String CHUNK_SIZE_KEY = "file.processing.buffer.chunk.size";
-  private static final int CHUNK_SIZE = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(CHUNK_SIZE_KEY, "50"));
-
+  private static final String MARC_RAW_CHUNK_SIZE_KEY = "file.processing.marc.raw.buffer.chunk.size";
+  private static final String MARC_JSON_CHUNK_SIZE_KEY = "file.processing.marc.json.buffer.chunk.size";
+  private static final String MARC_XML_CHUNK_SIZE_KEY = "file.processing.marc.xml.buffer.chunk.size";
+  private static final String EDIFACT_CHUNK_SIZE_KEY = "file.processing.edifact.buffer.chunk.size";
+  private static final int MARC_RAW_CHUNK_SIZE = Integer.parseInt(System.getProperty(MARC_RAW_CHUNK_SIZE_KEY, "50"));
+  private static final int MARC_JSON_CHUNK_SIZE = Integer.parseInt(System.getProperty(MARC_JSON_CHUNK_SIZE_KEY, "50"));
+  private static final int MARC_XML_CHUNK_SIZE = Integer.parseInt(System.getProperty(MARC_XML_CHUNK_SIZE_KEY, "10"));
+  private static final int EDIFACT_CHUNK_SIZE = Integer.parseInt(System.getProperty(EDIFACT_CHUNK_SIZE_KEY, "50"));
 
   private SourceReaderBuilder() {
   }
@@ -31,14 +34,14 @@ public class SourceReaderBuilder {
 
     if (isMarc(jobProfile)) {
       if (JSON_EXTENSION.equals(extension)) {
-        sourceReader = new MarcJsonReader(file, CHUNK_SIZE);
+        sourceReader = new MarcJsonReader(file, MARC_JSON_CHUNK_SIZE);
       } else if (XML_EXTENSION.equals(extension)) {
-        sourceReader = new MarcXmlReader(file, CHUNK_SIZE);
+        sourceReader = new MarcXmlReader(file, MARC_XML_CHUNK_SIZE);
       } else {
-        sourceReader = new MarcRawReader(file, CHUNK_SIZE);
+        sourceReader = new MarcRawReader(file, MARC_RAW_CHUNK_SIZE);
       }
     } else if (isEdifact(extension, jobProfile)) {
-      sourceReader = new EdifactReader(file, CHUNK_SIZE);
+      sourceReader = new EdifactReader(file, EDIFACT_CHUNK_SIZE);
     }
 
     return ofNullable(sourceReader).orElseThrow(() -> new UnsupportedOperationException("Unsupported file format"));
@@ -50,5 +53,6 @@ public class SourceReaderBuilder {
   }
 
   private static boolean isMarc(JobProfileInfo jobProfile) {
-    return jobProfile != null && jobProfile.getDataType() == JobProfileInfo.DataType.MARC;  }
+    return jobProfile != null && jobProfile.getDataType() == JobProfileInfo.DataType.MARC;
+  }
 }

--- a/src/test/java/org/folio/service/processing/ParallelFileChunkingProcessorUnitTest.java
+++ b/src/test/java/org/folio/service/processing/ParallelFileChunkingProcessorUnitTest.java
@@ -73,7 +73,6 @@ public class ParallelFileChunkingProcessorUnitTest extends AbstractRestTest {
   private static final String KAFKA_PORT_PROP_NAME = "KAFKA_PORT";
   private static final String KAFKA_MAX_REQUEST_SIZE = "MAX_REQUEST_SIZE";
   public static final String EXCEPTION_OCCURRED_WHILE_GETTING_RECORDERS_FROM_KAFKA = "Exception occurred while getting recorders from kafka {}";
-  public static final String EXCEPTION_OCCURRED_WHILE_UNZIPPING_EVENT_PAYLOAD = "Exception occurred while unzipping event payload {}";
 
   private static final int RECORDS_NUMBER = 62;
   private static final Logger LOGGER = LogManager.getLogger();
@@ -122,7 +121,7 @@ public class ParallelFileChunkingProcessorUnitTest extends AbstractRestTest {
 
     // then
     future.onComplete(ar -> {
-      assertTrue(ar.succeeded());
+      context.assertTrue(ar.succeeded());
       assertDataFromKafka(fileStorageService, CONTENT_TYPE_RAW, TENANT_ID_TEST_MARC_RAW);
       async.complete();
     });
@@ -198,7 +197,7 @@ public class ParallelFileChunkingProcessorUnitTest extends AbstractRestTest {
 
     // then
     future.onComplete(ar -> {
-      assertTrue(ar.succeeded());
+      context.assertTrue(ar.succeeded());
       assertDataFromKafka(fileStorageService, CONTENT_TYPE_JSON, TENANT_ID_TEST_MARC_JSON);
       async.complete();
     });
@@ -220,7 +219,7 @@ public class ParallelFileChunkingProcessorUnitTest extends AbstractRestTest {
 
     // then
     future.onComplete(ar -> {
-      assertTrue(ar.succeeded());
+      context.assertTrue(ar.succeeded());
       assertDataFromKafka(fileStorageService, CONTENT_TYPE_XML, TENANT_ID_TEST_MARC_XML);
       async.complete();
     });

--- a/src/test/java/org/folio/service/processing/ParallelFileChunkingProcessorUnitTest.java
+++ b/src/test/java/org/folio/service/processing/ParallelFileChunkingProcessorUnitTest.java
@@ -3,7 +3,6 @@ package org.folio.service.processing;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -14,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaTopicNameHelper;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.AbstractRestTest;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.FileDefinition;
@@ -28,7 +26,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -333,12 +330,7 @@ public class ParallelFileChunkingProcessorUnitTest extends AbstractRestTest {
       LOGGER.error(EXCEPTION_OCCURRED_WHILE_GETTING_RECORDERS_FROM_KAFKA, e.getMessage());
     }
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    RawRecordsDto rawRecordsDto = null;
-    try {
-      rawRecordsDto = new JsonObject(ZIPArchiver.unzip(obtainedEvent.getEventPayload())).mapTo(RawRecordsDto.class);
-    } catch (IOException e) {
-      LOGGER.error(EXCEPTION_OCCURRED_WHILE_UNZIPPING_EVENT_PAYLOAD, e.getMessage());
-    }
+    RawRecordsDto rawRecordsDto = Json.decodeValue(obtainedEvent.getEventPayload(), RawRecordsDto.class);
     verify(fileStorageService, times(1)).getFile(any());
 
     Assert.assertNotNull(rawRecordsDto);


### PR DESCRIPTION
## Purpose
since records chunk size depends on record type/format (e.g. xml format has more redundant syntax) it makes sense to have the ability to set records chunk size for particular record type separately

## Approach
* delete zipping operation for data-import payload before send to Kafka
* provide system properties for SourceReaderBuilder to set records chunk size for each record type and marc format (raw, json, xml) correspondingly
  * "file.processing.marc.raw.buffer.chunk.size" property with 50 size value by default for marc raw format
  *  "file.processing.marc.json.buffer.chunk.size" property with 50 size value by default for marc json format
  *  "file.processing.marc.xml.buffer.chunk.size" property with 10 size value by default for marc xml format (since the xml format is more redundant the proposed default value has been selected to not exceed "max.request.size" producer parameter which is 1048576 bytes by default)
  *   "file.processing.edifact.buffer.chunk.size" property with 50 size value by default for edifact record type



## Learning
[MODDATAIMP-548](https://issues.folio.org/browse/MODDATAIMP-548)