### PR TITLE
MODDATAIMP-557. Close Vertx Kafka producers that have not been closed

### DIFF
--- a/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
+++ b/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
@@ -165,8 +165,7 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
       boolean succeeded = ar.succeeded();
       LOGGER.info("Sending event to Kafka finished. ar.succeeded(): {} jobProfile: {}, eventType: {}",
         succeeded, jobProfile, eventType);
-      LOGGER.debug("Closing KafkaProducer jobProfile: {}", jobProfile);
-      producer.end(par -> LOGGER.debug("KafkaProducer has been closed jobProfile: {}", jobProfile));
+      producer.end(par -> producer.close());
       processFilePromise.handle(ar);
     });
 


### PR DESCRIPTION
## Purpose
In Vertx documentation for shared producer usage written: 
`When you are done with the producer, just close it, when all shared producers are closed, the resources will be released for you.`
Link: https://vertx.io/docs/vertx-kafka-client/java/#_sharing_a_producer

In debug mode we see that for we have static map of shared producers(marked as green) that always contains the single item for module mod-data-import, but for every import Vertx creates separate KafkaWriteStream(marked as blue) that contains link to shared producer and designed to write stream of data to Kafka {@link ProducerRecord}.
![Vertx Kafka Producers](https://user-images.githubusercontent.com/25097693/135040764-d4c2d240-03a6-4d4c-94f5-72110e18395d.jpg)
If we don't invoke producer's close() method, these KafkaWriteStream objects will never be deleted and with every import the map which contains these streams  would grow.

To answer question when close() method invoked in Vertx implementation, in debug mode I saw that for example we have 3 parallel imports, so we have 1 shared producer and 3 Kafka write streams created, when the first import completed 1 Kafka stream would be deleted and shared Kafka producer would contain 2 write streams after this, after all remaining imports the last close() call would delete shared producer from map and call physical producer's close() method

