### PR TITLE
MODDATAIMP-561. Acq unit in invoice field mapping profile causes import to complete with errors

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -178,14 +178,14 @@
             "invoice-storage.invoice-lines.item.post",
             "invoice-storage.invoice-lines.item.put",
             "invoice-storage.invoice-lines.collection.get",
-            "invoices.acquisitions-units-assignments.assign",
             "acquisitions-units.units.collection.get",
             "acquisitions-units.memberships.collection.get",
             "orders.po-lines.item.get",
             "orders-storage.order-invoice-relationships.collection.get",
             "orders-storage.order-invoice-relationships.item.post",
             "orders.po-lines.collection.get"
-          ]
+          ],
+          "permissionsDesired": ["invoices.acquisitions-units-assignments.assign"]
         },
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -178,6 +178,7 @@
             "invoice-storage.invoice-lines.item.post",
             "invoice-storage.invoice-lines.item.put",
             "invoice-storage.invoice-lines.collection.get",
+            "invoices.acquisitions-units-assignments.assign",
             "acquisitions-units.units.collection.get",
             "acquisitions-units.memberships.collection.get",
             "orders.po-lines.item.get",


### PR DESCRIPTION
## Purpose
In mod-inventory app we saw error stack trace and due to that import completes with errors:
`Caused by: org.folio.invoices.rest.exceptions.HttpException: User does not have permissions to manage acquisition units assignments - operation is restricted
        at org.folio.utils.UserPermissionsUtil.verifyUserHasAssignPermission(UserPermissionsUtil.java:31) ~[mod-invoice-fat.jar:?]
        at org.folio.rest.impl.InvoiceHelper.lambda$6(InvoiceHelper.java:172) ~[mod-invoice-fat.jar:?]`

Mod-Inventory throws this exception if Acq units are presented but permission `invoices.acquisitions-units-assignments.assign` is not provided.
https://github.com/folio-org/mod-invoice/blob/master/src/main/java/org/folio/utils/UserPermissionsUtil.java#L31


## Approach
Add necessary permission to mod-data-import to be able to successfully making import with acq units.
This permission added only to mod-data-import to be consistent with other invoice permission declarations(not added to mod-source-record-manager or mod-source-record-storage because those modules even don't have permission to create/edit invoice, so in this case adding permission to work with acq units is not necessary
