### PR TITLE
Moddataimp-491: Improve logging to be able to trace the path of each record and file_chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-XX-XX v2.2.0
+* [MODDATAIMP-491](https://issues.folio.org/browse/MODDATAIMP-491) Improve logging to be able to trace the path of each record and file_chunks
+
 ## 2021-07-30 v2.1.0
 * [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages
 

--- a/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
+++ b/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
@@ -179,9 +179,9 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
   }
 
   private KafkaProducerRecord<String, String> createKafkaProducerRecord(RawRecordsDto chunk) throws IOException {
-    String correlationId = UUID.randomUUID().toString();
+    String chunkId = UUID.randomUUID().toString();
     Event event = new Event()
-      .withId(correlationId)
+      .withId(chunkId)
       .withEventType(DI_RAW_RECORDS_CHUNK_READ.value())
       .withEventPayload(ZIPArchiver.zip(Json.encode(chunk)))
       .withEventMetadata(new EventMetadata()
@@ -198,14 +198,14 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
     record.addHeaders(kafkaHeaders);
 
     record.addHeader("jobExecutionId", jobExecutionId);
-    record.addHeader("correlationId", correlationId);
+    record.addHeader("chunkId", chunkId);
     record.addHeader("chunkNumber", String.valueOf(chunkNumber));
 
     if (chunk.getRecordsMetadata().getLast()) {
       record.addHeader(END_SENTINEL, "true");
     }
 
-    LOGGER.debug("Next chunk has been created: correlationId: {} chunkNumber: {}", correlationId, chunkNumber);
+    LOGGER.debug("Next chunk has been created: chunkId: {} chunkNumber: {}", chunkId, chunkNumber);
     return record;
   }
 

--- a/src/main/java/org/folio/service/processing/kafka/WriteStreamWrapper.java
+++ b/src/main/java/org/folio/service/processing/kafka/WriteStreamWrapper.java
@@ -72,19 +72,19 @@ public class WriteStreamWrapper implements WriteStream<KafkaProducerRecord<Strin
   }
 
   private void logChunkProcessingResult(List<KafkaHeader> headers, AsyncResult<Void> ar) {
-    String correlationId = null;
+    String chunkId = null;
     String chunkNumber = null;
     for (KafkaHeader h : headers) {
-      if ("correlationId".equals(h.key())) {
-        correlationId = h.value().toString();
+      if ("chunkId".equals(h.key())) {
+        chunkId = h.value().toString();
       } else if ("chunkNumber".equals(h.key())) {
         chunkNumber = h.value().toString();
       }
     }
     if (ar.succeeded()) {
-      LOGGER.debug("Next chunk has been written: correlationId: {} chunkNumber: {}", correlationId, chunkNumber);
+      LOGGER.debug("Next chunk has been written: chunkId: {} chunkNumber: {}", chunkId, chunkNumber);
     } else {
-      LOGGER.error("Next chunk has failed with errors correlationId: {} chunkNumber: {}", correlationId, chunkNumber, ar.cause());
+      LOGGER.error("Next chunk has failed with errors chunkId: {} chunkNumber: {}", chunkId, chunkNumber, ar.cause());
     }
   }
 }


### PR DESCRIPTION
## Purpose
We can change meaningless kafka header "correllationId" to "recordId" and "chunkId".

This changes have to be added to the: data-import, data-import-processing-core, srm, srs, inventory  and other core modules.

## Approach
Changed "correllationId" to "chunkId". 
Logs improved.


## Learning
JIRA: https://issues.folio.org/browse/MODDATAIMP-491
