### PR TITLE
MODDATAIMP-598 - Critical vulnerability in the Apache log4j

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-12-xx v2.2.1
+* [MODDATAIMP-598](https://issues.folio.org/browse/MODDATAIMP-598) Log4j (CVE-2021-44228) vulnerability correction
+
 ## 2021-10-06 v2.2.0
 * [MODSOURMAN-550](https://issues.folio.org/browse/MODSOURMAN-550) Reduce BE response payload for DI Landing Page to increase performance
 * [MODDATAIMP-480](https://issues.folio.org/browse/MODDATAIMP-480) Suppress harmless errors from Data Import logs

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.15.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Purpose
to fix  vulnerability that is present in log4j<= 2.14

## Approach
* upgrade log4j to 2.16.0

## Learning
[MODDATAIMP-598](https://issues.folio.org/browse/MODDATAIMP-598)