### PR TITLE
MODDATAIMP-599 - Juniper R2 2021 - Log4j vulnerability verification and correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-12-xx v2.1.5
+* [MODDATAIMP-599](https://issues.folio.org/browse/MODDATAIMP-599) Log4j vulnerability correction
+
 ## 2021-10-08 v2.1.4
 * [MODDATAIMP-561](https://issues.folio.org/browse/MODDATAIMP-561) Add permission for acquisitions units assignments
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Purpose
to fix the vulnerability that is present in log4j<= 2.14

## Approach
* upgrade log4j version to 2.16.0

## Learning
[MODDATAIMP-599](https://issues.folio.org/browse/MODDATAIMP-599)