### PR TITLE
MODDATAIMP-635 Check if any 3d party dependencies should be update for DI modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.2.3</raml-module-builder.version>
-    <vertx.version>4.2.2</vertx.version>
+    <raml-module-builder.version>33.2.6</raml-module-builder.version>
+    <vertx.version>4.2.5</vertx.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <jackson.version>2.10.5.1</jackson.version>
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.6</version>
+      <version>2.8.9</version>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.2.6</raml-module-builder.version>
-    <vertx.version>4.2.5</vertx.version>
+    <raml-module-builder.version>33.2.3</raml-module-builder.version>
+    <vertx.version>4.2.2</vertx.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <jackson.version>2.10.5.1</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.3.0-SNAPSHOT</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
## Purpose
Using the latest versions helps us avoid possible problems with the libraries.

## Approach

- upgraded gson from 2.8.6 to 2.8.9
- upgraded data-import-processing-core from 3.2.0 to 3.3.0

## Learning
[MODDATAIMP-635](https://issues.folio.org/browse/MODDATAIMP-635)
