### PR TITLE
Adjust default MAX_REQUEST_SIZE

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -27,7 +27,7 @@ public class ApplicationConfig {
   private String okapiUrl;
   @Value("${REPLICATION_FACTOR:1}")
   private int replicationFactor;
-  @Value("${MAX_REQUEST_SIZE:1048576}")
+  @Value("${MAX_REQUEST_SIZE:4000000}")
   private int maxRequestSize;
   @Value("${ENV:folio}")
   private String envId;


### PR DESCRIPTION
Even though Kafka message payload was significantly decreased, it is still recommended to adjust MAX_REQUEST_SIZE value to allow importing large files. Setting default value to 4000000 bytes would make adjustment of that property unnecessary.