### PR TITLE
MODDATAIMP-646: Logs show incorrectly formatted request id.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2022-xx-xx v2.5.0-SNAPSHOT
 * [MODDATAIMP-472](https://issues.folio.org/browse/MODDATAIMP-472) EDIFACT files with txt file extensions do not import
+* [MODDATAIMP-646](https://issues.folio.org/browse/MODDATAIMP-646) Logs show incorrectly formatted request id
 
 
 ## 2022-03-03 v2.4.0

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -3,11 +3,6 @@ name = PropertiesConfig
 
 packages = org.folio.okapi.common.logging
 
-filters = threshold
-
-filter.threshold.type = ThresholdFilter
-filter.threshold.level = info
-
 appenders = console
 
 appender.console.type = Console

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,10 +1,19 @@
 status = warn
 name = PropertiesConfig
 
+packages = org.folio.okapi.common.logging
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = console
+
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5p %-20.20C{1} [%reqId] %m%n
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] [$${FolioLoggingContext:requestid}] %-5p %-20.20C{1} %m%n
 
 logger.folio.name = org.folio
 #logger.folio.level = debug


### PR DESCRIPTION
## Purpose
Improve logging. Added FOLIO-approach for retrieving properties for logging.

## Approach
Retreiving properties from FolioLoggingContext.

#### TODOS and Open Questions

- It seems like these properties are available only for REST-requests.

## Learning
https://issues.folio.org/browse/MODDATAIMP-646
