### PR TITLE
MODDATAIMP-696 - Upgrade RMB to v34.1.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## 2022-xx-xx v2.5.0-SNAPSHOT
 * [MODDATAIMP-472](https://issues.folio.org/browse/MODDATAIMP-472) EDIFACT files with txt file extensions do not import
 * [MODDATAIMP-646](https://issues.folio.org/browse/MODDATAIMP-646) Logs show incorrectly formatted request id
-
+* [MODDATAIMP-696](https://issues.folio.org/browse/MODDATAIMP-696) Upgrade RMB to v34.1.0
 
 ## 2022-03-03 v2.4.0
 * Update RMB to v33.2.6

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.2.6</raml-module-builder.version>
-    <vertx.version>4.2.5</vertx.version>
+    <raml-module-builder.version>34.1.0</raml-module-builder.version>
+    <vertx.version>4.3.1</vertx.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <marc4j.version>2.9.1</marc4j.version>

--- a/src/main/java/org/folio/dao/UploadDefinitionDaoImpl.java
+++ b/src/main/java/org/folio/dao/UploadDefinitionDaoImpl.java
@@ -42,7 +42,7 @@ import static org.folio.rest.jaxrs.model.UploadDefinition.Status.COMPLETED;
 public class UploadDefinitionDaoImpl implements UploadDefinitionDao {
 
   private static final String UPLOAD_DEFINITION_TABLE = "upload_definitions";
-  private static final String UPLOAD_DEFINITION_ID_FIELD = "'id'";
+  private static final String UPLOAD_DEFINITION_ID_FIELD = "id";
   private static final String STATUS_FIELD = "'status'";
   private static final String METADATA_FIELD = "'metadata'";
   private static final String UPDATED_DATE_FIELD = "'updatedDate'";
@@ -143,8 +143,8 @@ public class UploadDefinitionDaoImpl implements UploadDefinitionDao {
   public Future<Optional<UploadDefinition>> getUploadDefinitionById(String id, String tenantId) {
     Promise<Results<UploadDefinition>> promise = Promise.promise();
     try {
-      Criteria idCrit = constructCriteria(UPLOAD_DEFINITION_ID_FIELD, id);
-      pgClientFactory.createInstance(tenantId).get(UPLOAD_DEFINITION_TABLE, UploadDefinition.class, new Criterion(idCrit), true, promise);
+      Criteria idCrit = constructCriteria(UPLOAD_DEFINITION_ID_FIELD, id).setJSONB(false);
+      pgClientFactory.createInstance(tenantId).get(UPLOAD_DEFINITION_TABLE, UploadDefinition.class, new Criterion(idCrit), false, promise);
     } catch (Exception e) {
       LOGGER.error("Error during get UploadDefinition by ID from view", e);
       promise.fail(e);

--- a/src/main/java/org/folio/dao/UploadDefinitionDaoImpl.java
+++ b/src/main/java/org/folio/dao/UploadDefinitionDaoImpl.java
@@ -36,13 +36,17 @@ import java.util.TimeZone;
 
 import static org.folio.dataimport.util.DaoUtil.constructCriteria;
 import static org.folio.dataimport.util.DaoUtil.getCQLWrapper;
+import static org.folio.rest.jaxrs.model.UploadDefinition.Status.COMPLETED;
 
 @Repository
 public class UploadDefinitionDaoImpl implements UploadDefinitionDao {
 
   private static final String UPLOAD_DEFINITION_TABLE = "upload_definitions";
   private static final String UPLOAD_DEFINITION_ID_FIELD = "'id'";
-  public static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd HH:mm:ss";
+  private static final String STATUS_FIELD = "'status'";
+  private static final String METADATA_FIELD = "'metadata'";
+  private static final String UPDATED_DATE_FIELD = "'updatedDate'";
+  private static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 
   private static final Logger LOGGER = LogManager.getLogger();
   private SimpleDateFormat dateFormatter;
@@ -181,9 +185,8 @@ public class UploadDefinitionDaoImpl implements UploadDefinitionDao {
   public Future<DefinitionCollection> getUploadDefinitionsByStatusOrUpdatedDateNotGreaterThen(Status status, Date lastUpdateDate, int offset, int limit, String tenantId) {
     Promise<Results<UploadDefinition>> promise = Promise.promise();
     try {
-      String[] fieldList = {"*"};
-      String queryFilter = getFilterByStatus(status, lastUpdateDate);
-      pgClientFactory.createInstance(tenantId).get(UPLOAD_DEFINITION_TABLE, UploadDefinition.class, fieldList, queryFilter, true, false, promise);
+      Criterion filter = getFilterByStatus(status, lastUpdateDate);
+      pgClientFactory.createInstance(tenantId).get(UPLOAD_DEFINITION_TABLE, UploadDefinition.class, filter, true, promise);
     } catch (Exception e) {
       LOGGER.error("Error during getting UploadDefinitions by status and date", e);
       promise.fail(e);
@@ -193,8 +196,14 @@ public class UploadDefinitionDaoImpl implements UploadDefinitionDao {
       .withTotalRecords(uploadDefinitionResults.getResultInfo().getTotalRecords()));
   }
 
-  private String getFilterByStatus(Status status, Date date) {
-    String queryFilterTemplate = "WHERE %s.jsonb ->> 'status' = '%s' OR TO_TIMESTAMP(%s.jsonb -> 'metadata' ->> 'updatedDate', 'YYYY-MM-DD\"T\"HH24:MI:SS') <= '%s'";
-    return String.format(queryFilterTemplate, UPLOAD_DEFINITION_TABLE, status.toString(), UPLOAD_DEFINITION_TABLE, dateFormatter.format(date));
+  private Criterion getFilterByStatus(Status status, Date date) {
+    Criteria updatedDateCriteria = new Criteria()
+      .addField(METADATA_FIELD)
+      .addField(UPDATED_DATE_FIELD)
+      .setOperation("<=")
+      .setVal(dateFormatter.format(date));
+
+    return new Criterion(constructCriteria(STATUS_FIELD, COMPLETED.value()))
+      .addCriterion(updatedDateCriteria, "OR");
   }
 }

--- a/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
+++ b/src/main/java/org/folio/service/fileextension/FileExtensionServiceImpl.java
@@ -161,9 +161,9 @@ public class FileExtensionServiceImpl implements FileExtensionService {
 
   @Override
   public Future<Boolean> isFileExtensionExistByName(FileExtension fileExtension, String tenantId) {
-    StringBuilder query = new StringBuilder("extension=" + fileExtension.getExtension().trim());
+    StringBuilder query = new StringBuilder("extension==" + fileExtension.getExtension().trim());
     if (fileExtension.getId() != null) {
-      query.append(" AND id=\"\" NOT id=")
+      query.append(" AND id <> ")
         .append(fileExtension.getId());
     }
     return fileExtensionDao.getFileExtensions(query.toString(), 0, 1, tenantId)

--- a/src/test/java/org/folio/rest/FileExtensionAPITest.java
+++ b/src/test/java/org/folio/rest/FileExtensionAPITest.java
@@ -9,6 +9,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.DataType;
 import org.folio.rest.jaxrs.model.FileExtension;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -318,7 +319,7 @@ public class FileExtensionAPITest extends AbstractRestTest {
       .body(fileExtension_7)
       .when()
       .post(FILE_EXTENSION_PATH);
-    Assert.assertThat(createResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    MatcherAssert.assertThat(createResponse.statusCode(), is(HttpStatus.SC_CREATED));
     FileExtension fileExtension = createResponse.body().as(FileExtension.class);
     async2.complete();
 

--- a/src/test/java/org/folio/service/cleanup/StorageCleanupServiceImplTest.java
+++ b/src/test/java/org/folio/service/cleanup/StorageCleanupServiceImplTest.java
@@ -18,7 +18,6 @@ import org.folio.service.AbstractIntegrationTest;
 import org.folio.service.config.ApplicationTestConfig;
 import org.folio.spring.SpringContextUtil;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -115,9 +114,9 @@ public class StorageCleanupServiceImplTest extends AbstractIntegrationTest {
       Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
 
       future.onComplete(ar -> {
-        Assert.assertTrue(ar.succeeded());
-        Assert.assertTrue(ar.result());
-        Assert.assertFalse(testFile.exists());
+        context.assertTrue(ar.succeeded());
+        context.assertTrue(ar.result());
+        context.assertFalse(testFile.exists());
         async.complete();
       });
       return future;
@@ -135,9 +134,9 @@ public class StorageCleanupServiceImplTest extends AbstractIntegrationTest {
       Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
 
       future.onComplete(ar -> {
-        Assert.assertTrue(ar.succeeded());
-        Assert.assertTrue(ar.result());
-        Assert.assertFalse(testFile.exists());
+        context.assertTrue(ar.succeeded());
+        context.assertTrue(ar.result());
+        context.assertFalse(testFile.exists());
         async.complete();
       });
       return future;
@@ -152,9 +151,9 @@ public class StorageCleanupServiceImplTest extends AbstractIntegrationTest {
       Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
 
       future.onComplete(ar -> {
-        Assert.assertTrue(ar.succeeded());
-        Assert.assertFalse(ar.result());
-        Assert.assertTrue(testFile.exists());
+        context.assertTrue(ar.succeeded());
+        context.assertFalse(ar.result());
+        context.assertTrue(testFile.exists());
         async.complete();
       });
       return future;
@@ -172,7 +171,7 @@ public class StorageCleanupServiceImplTest extends AbstractIntegrationTest {
 
       future.onComplete(ar -> {
         context.assertTrue(ar.succeeded());
-        Assert.assertFalse(ar.result());
+        context.assertFalse(ar.result());
         async.complete();
       });
       return future;


### PR DESCRIPTION
## Approach
* updated RMB to 34.1.0
* since the PostgresClient.get method which consumes String filter parameter has been deleted from RMB v34.1.0, replaced it with PostgresClient.get method which expects Criterion parameter
* Fixed file extension existence check due to introduced changes in RMB-917


## Learning
[MODDATAIMP-696](https://issues.folio.org/browse/MODDATAIMP-696)