### PR TITLE
MODDATAIMP-730: Spring 5.3, kafkaclients 3.2.3, folio-di-support 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,8 @@
     <sonar.exclusions>**/ModTenantAPI.java</sonar.exclusions>
     <sonar.exclusions>**/ApplicationConfig.java</sonar.exclusions>
     <lombok.version>1.18.12</lombok.version>
-    <kafkaclients.version>3.1.0</kafkaclients.version>
+    <kafkaclients.version>3.2.3</kafkaclients.version>
+    <kafka-junit.version>3.2.2</kafka-junit.version>
   </properties>
 
   <dependencyManagement>
@@ -41,6 +42,13 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>5.3.23</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -76,6 +84,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.marc4j</groupId>
       <artifactId>marc4j</artifactId>
       <version>${marc4j.version}</version>
@@ -83,7 +95,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-di-support</artifactId>
-      <version>1.4.1</version>
+      <version>1.7.0</version>
       <type>jar</type>
     </dependency>
     <dependency>
@@ -171,14 +183,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.13</version>
-    </dependency>
-    <dependency>
       <groupId>pl.pragmatists</groupId>
       <artifactId>JUnitParams</artifactId>
       <version>1.1.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
@@ -215,7 +223,7 @@
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>${kafkaclients.version}</version>
+      <version>${kafka-junit.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Upgrade kafkaclients from 3.1.0 to 3.2.3 fixing Memory Allocation with Excessive Size Value: https://nvd.nist.gov/vuln/detail/CVE-2022-34917

Upgrade kafka-junit from 3.1.0 to 3.2.2 to match the kafkaclients version.

Remove unsed httpclient. This indirectly removes commons-codec 1.11 that has Information Exposure vulnerability: https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518

Remove JUnitParams from runtime, use for test only. This indirectly removes junit 4.12 from runtime that has an Information Exposure vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2020-15250

Upgrade springframework from 5.2.8.RELEASE to 5.3.22. Note that open source spring 5.2.* has reached it's end of life and has been out of support since 2021-12-31: https://spring.io/projects/spring-framework#support

Remove unused spring-beans 5.2.8.RELEASE dependency that has the Spring4Shell Remote Code Execution vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2022-22965