### PR TITLE
MODDATAIMP-732: Spring 5.2.22 fixing Spring4Shell CVE-2022-22965

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>5.2.22.RELEASE</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Upgrade springframework from 5.2.8.RELEASE to 5.2.22.RELEASE to fix the Spring4Shell Remote Code Execution vulnerability in spring-beans:
https://issues.folio.org/browse/FOLIO-3466
https://nvd.nist.gov/vuln/detail/CVE-2022-22965

Before the upgrade:

```
$ mvn dependency:tree -Dincludes=org.springframework
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ mod-data-import ---
[INFO] org.folio:mod-data-import:jar:2.5.1-SNAPSHOT
[INFO] \- org.folio:folio-di-support:jar:1.4.1:compile
[INFO]    +- org.springframework:spring-core:jar:5.2.8.RELEASE:compile
[INFO]    |  \- org.springframework:spring-jcl:jar:5.2.8.RELEASE:compile
[INFO]    \- org.springframework:spring-context:jar:5.2.8.RELEASE:compile
[INFO]       +- org.springframework:spring-aop:jar:5.2.8.RELEASE:compile
[INFO]       +- org.springframework:spring-beans:jar:5.2.8.RELEASE:compile
[INFO]       \- org.springframework:spring-expression:jar:5.2.8.RELEASE:compile
```

After the upgrade:

```
$ mvn dependency:tree -Dincludes=org.springframework
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ mod-data-import ---
[INFO] org.folio:mod-data-import:jar:2.5.1-SNAPSHOT
[INFO] \- org.folio:folio-di-support:jar:1.4.1:compile
[INFO]    +- org.springframework:spring-core:jar:5.2.22.RELEASE:compile
[INFO]    |  \- org.springframework:spring-jcl:jar:5.2.22.RELEASE:compile
[INFO]    \- org.springframework:spring-context:jar:5.2.22.RELEASE:compile
[INFO]       +- org.springframework:spring-aop:jar:5.2.22.RELEASE:compile
[INFO]       +- org.springframework:spring-beans:jar:5.2.22.RELEASE:compile
[INFO]       \- org.springframework:spring-expression:jar:5.2.22.RELEASE:compile
```