### PR TITLE
FAT-3397 - Put actual chunk id to kafka headers to correlate log messages for particular chunk

### DIFF
--- a/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
+++ b/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
@@ -158,6 +158,7 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
 
         } else {
           chunk = new RawRecordsDto()
+            .withId(UUID.randomUUID().toString())
             .withRecordsMetadata(new RecordsMetadata()
               .withContentType(reader.getContentType())
               .withCounter(recordsCounter)
@@ -178,10 +179,9 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
     });
   }
 
-  private KafkaProducerRecord<String, String> createKafkaProducerRecord(RawRecordsDto chunk) throws IOException {
-    String chunkId = UUID.randomUUID().toString();
+  private KafkaProducerRecord<String, String> createKafkaProducerRecord(RawRecordsDto chunk) {
     Event event = new Event()
-      .withId(chunkId)
+      .withId(chunk.getId())
       .withEventType(DI_RAW_RECORDS_CHUNK_READ.value())
       .withEventPayload(Json.encode(chunk))
       .withEventMetadata(new EventMetadata()
@@ -198,14 +198,14 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
     record.addHeaders(kafkaHeaders);
 
     record.addHeader("jobExecutionId", jobExecutionId);
-    record.addHeader("chunkId", chunkId);
+    record.addHeader("chunkId", chunk.getId());
     record.addHeader("chunkNumber", String.valueOf(chunkNumber));
 
     if (chunk.getRecordsMetadata().getLast()) {
       record.addHeader(END_SENTINEL, "true");
     }
 
-    LOGGER.debug("Next chunk has been created: chunkId: {} chunkNumber: {}", chunkId, chunkNumber);
+    LOGGER.debug("Next chunk has been created: chunkId: {} chunkNumber: {}", chunk.getId(), chunkNumber);
     return record;
   }
 

--- a/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
+++ b/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
@@ -11,7 +11,6 @@ import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
 import org.folio.rest.jaxrs.model.InitialRecord;
@@ -19,7 +18,6 @@ import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.rest.jaxrs.model.RecordsMetadata;
 import org.folio.service.processing.reader.SourceReader;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;


### PR DESCRIPTION
## Purpose
to be able to correlate log messages for the same chunk of records. Spotted during investigation [FAT-3397](https://issues.folio.org/browse/FAT-3397)

Example of log messages that refer to the same chunk of records:
> "Starting to process raw records chunk with id: **1a3ff3c9-2510-4658-b615-dec4cc9586e0** for jobExecutionId: bc6362e6-aa48-40b2-a503-1400d194ad8b. Chunk size: 1."
...
> "Event with type: DI_RAW_RECORDS_CHUNK_PARSED and chunkId: **28aba248-82f6-4656-b869-522f4afa1ef2** was sent to kafka"
> 
> 

## Approach
* put the actual id of records chunk to Kafka headers

