### PR TITLE
[MODDATAIMP-757]Add missed permissions for invoice data import flow

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -193,9 +193,18 @@
             "acquisitions-units.units.collection.get",
             "acquisitions-units.memberships.collection.get",
             "orders.po-lines.item.get",
+            "orders.po-lines.collection.get",
             "orders-storage.order-invoice-relationships.collection.get",
             "orders-storage.order-invoice-relationships.item.post",
-            "orders.po-lines.collection.get"
+            "finance.exchange-rate.item.get",
+            "finance.expense-classes.collection.get",
+            "finance.funds.budget.item.get",
+            "finance.fiscal-years.item.get",
+            "finance.ledgers.collection.get",
+            "finance.transactions.collection.get",
+            "finance-storage.budgets.collection.get",
+            "finance-storage.budget-expense-classes.collection.get",
+            "finance-storage.fiscal-years.item.get"
           ],
           "permissionsDesired": ["invoices.acquisitions-units-assignments.assign"]
         },


### PR DESCRIPTION
https://issues.folio.org/browse/MODDATAIMP-757
After updating implementation of creating invoice flow the permissinon set has been updated. In order to support these changes in invoice data import flow the permission set in mod-data-import should be updated as well.

Following permissions should be added:

"orders-storage.order-invoice-relationships.item.post",
"finance-storage.budget-expense-classes.collection.get",
"finance.ledgers.collection.get",
"finance.funds.budget.item.get",
"finance-storage.fiscal-years.item.get",
"finance.fiscal-years.item.get",
"finance-storage.budgets.collection.get",
"finance.transactions.collection.get",
"finance.expense-classes.collection.get",
"finance.exchange-rate.item.get"