### PR TITLE
Update version of test containers to support Mac M1 processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
-      <version>1.15.3</version>
+      <version>1.18.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Purpose
When trying to execute `mvn install` I encountered the following errors

```
ERROR PostgresClient       Could not find a valid Docker environment. Please see logs and check configuration
java.lang.IllegalStateException: Could not find a valid Docker environment. Please see logs and check configuration
.....
[ERROR] Failures: 
[ERROR]   DefaultFileExtensionAPITest>AbstractRestTest.lambda$setUpClass$1:197 Not equals : Failed to make post tenant. Received status code 400 != Cannot invoke "org.folio.rest.persist.PostgresClient.select(String)" because the return value of "org.folio.rest.impl.TenantAPI.postgresClient(io.vertx.core.Context)" is null
```

My development machine is a Mac with M1 chip

I am locally running Docker Desktop with a configured postgres:12-alpine container

After research, found that
`older versions of testcontainers uses libraries that Apple M1 chips aren't compatible with`

Current version is `1.18.3` https://mvnrepository.com/artifact/org.testcontainers/kafka

## Approach
- Upgrade version of testcontainers to a later version so that is Mac M1 compatible

#### TODOS and Open Questions
- [x] Check by developer with non Mac environment
- [x] PR for changes to Orchid release branch - https://github.com/folio-org/mod-data-import/tree/release/2023_R1_v2.7.0_Orchid

## Learning
Helpful link regarding this issue
(https://stackoverflow.com/questions/72716456/java-lang-illegalstateexception-could-not-find-a-valid-docker-environment-plea)
