### PR TITLE
MODDATAIMP-846: Add GET /uploadUrl endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ To allow multiple instance deployment, for every instance the same persistent vo
 * **_data.import.storage.type_** - type of data storage used for uploaded files. Default value is **LOCAL_STORAGE**. Other implementations for storage should be added.
 * **_data.import.storage.path_** - **path where uploaded file will be stored**
 
+## Interaction with AWS S3/Minio
+
+This module uses S3-compatible storage as part of the file upload process.  The following environment variables must be set with values for your S3-compatible storage (AWS S3, Minio Server):
+
+| Name                    | Description                                                                |
+|-------------------------|----------------------------------------------------------------------------|
+| `AWS_URL`               | URL of S3-compatible storage, e.g. `http://127.0.0.1:9000/`                |
+| `AWS_REGION`            | S3 region                                                                  |
+| `AWS_BUCKET`            | Bucket to store and retrieve data                                          |
+| `AWS_ACCESS_KEY_ID`     | S3 access key                                                              |
+| `AWS_SECRET_ACCESS_KEY` | S3 secret key                                                              |
+| `AWS_SDK`               | If AWS S3 is being used (should be `"true"` if so and `"false"` otherwise) |
+
 ## Interaction with Kafka
 
 All modules involved in data import (mod-data-import, mod-source-record-manager, mod-source-record-storage, mod-inventory, mod-invoice) are communicating via Kafka directly. Therefore, to enable data import Kafka should be set up properly and all the necessary parameters should be set for the modules.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -400,7 +400,13 @@
       { "name": "DB_CHARSET", "value": "UTF-8" },
       { "name": "DB_MAXPOOLSIZE", "value": "5" },
       { "name": "KAFKA_HOST", "value": "10.0.2.15"},
-      { "name": "KAFKA_PORT", "value": "9092"}
+      { "name": "KAFKA_PORT", "value": "9092"},
+      { "name": "AWS_URL", "value": "http://127.0.0.1:9000/" },
+      { "name": "AWS_REGION", "value": "" },
+      { "name": "AWS_BUCKET", "value": "example-bucket" },
+      { "name": "AWS_ACCESS_KEY_ID", "value": "AKIAIOSFODNN7EXAMPLE" },
+      { "name": "AWS_SECRET_ACCESS_KEY", "value": "wJalrXUtnFEMI/K7MDENG/EXAMPLEKEY" },
+      { "name": "AWS_SDK", "value": "false" }
     ]
   }
 }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -267,6 +267,11 @@
           "methods": ["GET"],
           "pathPattern": "/data-import/dataTypes",
           "permissionsRequired": ["data-import.datatypes.get"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/data-import/uploadUrl",
+          "permissionsRequired": ["data-import.uploadUrl.get"]
         }
       ]
     },
@@ -357,11 +362,17 @@
       "description": "Get DataTypes"
     },
     {
+      "permissionName": "data-import.uploadUrl.get",
+      "displayName": "Data Import - get S3 upload URL",
+      "description": "Get S3 upload URL"
+    },
+    {
       "permissionName": "data-import.upload.all",
       "displayName": "Data Import File Upload - all permissions",
       "description": "Entire set of permissions needed to use file uploads",
       "subPermissions": [
         "data-import.upload.file.post",
+        "data-import.uploadUrl.get",
         "data-import.uploaddefinitions.post",
         "data-import.uploaddefinitions.get",
         "data-import.uploaddefinitions.put",

--- a/pom.xml
+++ b/pom.xml
@@ -533,6 +533,9 @@
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>**/Log4j2Plugins.dat</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
     <kafkaclients.version>3.3.2</kafkaclients.version>
     <kafka-junit.version>3.3.0</kafka-junit.version>
     <spring.version>5.3.23</spring.version>
+    <folio-s3-client.version>1.1.0-SNAPSHOT</folio-s3-client.version>
+    <aws-sdk-java.version>2.19.2</aws-sdk-java.version>
   </properties>
 
   <dependencyManagement>
@@ -118,6 +120,16 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-s3-client</artifactId>
+      <version>${folio-s3-client.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <version>${aws-sdk-java.version}</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -218,7 +230,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
-      <version>1.15.3</version>
+      <version>1.18.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/ramls/dataImport.raml
+++ b/ramls/dataImport.raml
@@ -29,7 +29,7 @@ types:
   dataTypeCollection: !include raml-storage/schemas/mod-data-import/dataTypeCollection.json
   dataImportEventTypes: !include raml-storage/schemas/common/dataImportEventTypes.json
   dataImportInitConfig: !include raml-storage/schemas/common/dataImportInitConfig.json
-  userInfo: !include raml-storage/schemas/common/userInfo.json
+  fileUploadInfo: !include fileUploadInfo.json
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml
@@ -254,14 +254,18 @@ resourceTypes:
           body:
             text/plain:
               example: "Internal server error"
-  /uploadUrls:
+  /uploadUrl:
     get:
       description: Get an upload url
+      queryParameters:
+        fileName:
+          description: "fileName parameter"
+          required: true
       responses:
         200:
           body:
             application/json:
-              type: userInfo
+              type: fileUploadInfo
         400:
           description: "Bad request"
           body:

--- a/ramls/dataImport.raml
+++ b/ramls/dataImport.raml
@@ -29,6 +29,7 @@ types:
   dataTypeCollection: !include raml-storage/schemas/mod-data-import/dataTypeCollection.json
   dataImportEventTypes: !include raml-storage/schemas/common/dataImportEventTypes.json
   dataImportInitConfig: !include raml-storage/schemas/common/dataImportInitConfig.json
+  userInfo: !include raml-storage/schemas/common/userInfo.json
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml
@@ -243,6 +244,24 @@ resourceTypes:
           body:
             application/json:
               type: dataTypeCollection
+        400:
+          description: "Bad request"
+          body:
+            text/plain:
+              example: "Bad request"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
+  /uploadUrls:
+    get:
+      description: Get an upload url
+      responses:
+        200:
+          body:
+            application/json:
+              type: userInfo
         400:
           description: "Bad request"
           body:

--- a/ramls/fileUploadInfo.json
+++ b/ramls/fileUploadInfo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "file upload info json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "url": {
+      "description": "presigned url to be used for direct s3 upload",
+      "type": "string"
+    },
+    "key": {
+      "description": "Key for file upload on S3 storage",
+      "type": "string"
+    }
+  },
+  "required": [
+    "url",
+    "key"
+  ]
+}

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @ComponentScan(basePackages = {
@@ -15,7 +16,10 @@ import org.springframework.context.annotation.Configuration;
   "org.folio.service.file",
   "org.folio.service.fileextension",
   "org.folio.service.upload",
-  "org.folio.service.cleanup"})
+  "org.folio.service.cleanup",
+  "org.folio.service.s3storage"
+})
+@PropertySource("classpath:minio.properties")
 public class ApplicationConfig {
   private static final Logger LOGGER = LogManager.getLogger();
 

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -430,17 +430,17 @@ public class DataImportImpl implements DataImport {
   }
 
   @Override
-  public void getDataImportUploadUrls(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getDataImportUploadUrl(String fileName, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        LOGGER.debug("getDataImportUploadUrls:: getting upload url");
-        minioStorageService.getFileUploadUrl("bee-icon.png", tenantId)
-          .map(GetDataImportUploadUrlsResponse::respond200WithApplicationJson)
+        LOGGER.debug("getDataImportUploadUrl:: getting upload url");
+        minioStorageService.getFileUploadUrl(fileName, tenantId)
+          .map(GetDataImportUploadUrlResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .onComplete(asyncResultHandler);
       } catch (Exception e) {
-        LOGGER.warn("getDataImportUploadUrls:: Failed to get upload url", e);
+        LOGGER.warn("getDataImportUploadUrl:: Failed to get upload url", e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
       }
     });

--- a/src/main/java/org/folio/service/s3storage/FolioS3ClientFactory.java
+++ b/src/main/java/org/folio/service/s3storage/FolioS3ClientFactory.java
@@ -2,7 +2,6 @@ package org.folio.service.s3storage;
 
 import org.folio.s3.client.FolioS3Client;
 import org.folio.s3.client.S3ClientFactory;
-
 import org.folio.s3.client.S3ClientProperties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -28,7 +27,11 @@ public class FolioS3ClientFactory {
   @Value("#{ T(Boolean).parseBoolean('${minio.awsSdk}')}")
   private boolean awsSdk;
 
-  private FolioS3Client folioS3Client; //NOSONAR
+  private FolioS3Client folioS3Client;
+
+  public FolioS3ClientFactory() {
+    this.folioS3Client = null;
+  }
 
   public FolioS3Client getFolioS3Client() {
     if (folioS3Client != null) {
@@ -39,13 +42,16 @@ public class FolioS3ClientFactory {
   }
 
   private FolioS3Client createFolioS3Client() {
-    return S3ClientFactory.getS3Client(S3ClientProperties.builder()
-      .endpoint(endpoint)
-      .secretKey(secretKey)
-      .accessKey(accessKey)
-      .bucket(bucket)
-      .awsSdk(awsSdk)
-      .region(region)
-      .build());
+    return S3ClientFactory.getS3Client(
+      S3ClientProperties
+        .builder()
+        .endpoint(endpoint)
+        .accessKey(accessKey)
+        .secretKey(secretKey)
+        .bucket(bucket)
+        .awsSdk(awsSdk)
+        .region(region)
+        .build()
+    );
   }
 }

--- a/src/main/java/org/folio/service/s3storage/FolioS3ClientFactory.java
+++ b/src/main/java/org/folio/service/s3storage/FolioS3ClientFactory.java
@@ -1,0 +1,51 @@
+package org.folio.service.s3storage;
+
+import org.folio.s3.client.FolioS3Client;
+import org.folio.s3.client.S3ClientFactory;
+
+import org.folio.s3.client.S3ClientProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FolioS3ClientFactory {
+
+  @Value("${minio.endpoint}")
+  private String endpoint;
+
+  @Value("${minio.accessKey}")
+  private String accessKey;
+
+  @Value("${minio.secretKey}")
+  private String secretKey;
+
+  @Value("${minio.bucket}")
+  private String bucket;
+
+  @Value("${minio.region}")
+  private String region;
+
+  @Value("#{ T(Boolean).parseBoolean('${minio.awsSdk}')}")
+  private boolean awsSdk;
+
+  private FolioS3Client folioS3Client; //NOSONAR
+
+  public FolioS3Client getFolioS3Client() {
+    if (folioS3Client != null) {
+      return folioS3Client;
+    }
+    folioS3Client = createFolioS3Client();
+    return folioS3Client;
+  }
+
+  private FolioS3Client createFolioS3Client() {
+    return S3ClientFactory.getS3Client(S3ClientProperties.builder()
+      .endpoint(endpoint)
+      .secretKey(secretKey)
+      .accessKey(accessKey)
+      .bucket(bucket)
+      .awsSdk(awsSdk)
+      .region(region)
+      .build());
+  }
+}

--- a/src/main/java/org/folio/service/s3storage/MinioStorageService.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageService.java
@@ -4,7 +4,6 @@ import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.FileUploadInfo;
 
 public interface MinioStorageService {
-
   /*
    * Gets upload url and key for a file upload
    *
@@ -13,9 +12,10 @@ public interface MinioStorageService {
    *
    * @return FileUploadInfo
    *  url - presigned Url to S3 storage
-   *  key  - key for access to file on S3 storage
+   *  key - key for access to file on S3 storage
    */
-  Future<FileUploadInfo> getFileUploadUrl(String upLoadFileName, String tenantId);
-
-
+  Future<FileUploadInfo> getFileUploadUrl(
+    String uploadFileName,
+    String tenantId
+  );
 }

--- a/src/main/java/org/folio/service/s3storage/MinioStorageService.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageService.java
@@ -1,14 +1,14 @@
 package org.folio.service.s3storage;
 
 import io.vertx.core.Future;
-import org.folio.rest.jaxrs.model.UserInfo;
+import org.folio.rest.jaxrs.model.FileUploadInfo;
 
 public interface MinioStorageService {
 
   /*
    *
    */
-  Future<UserInfo> getFileUploadUrl(String upLoadFileName, String tenantId);
+  Future<FileUploadInfo> getFileUploadUrl(String upLoadFileName, String tenantId);
 
 
 }

--- a/src/main/java/org/folio/service/s3storage/MinioStorageService.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageService.java
@@ -1,13 +1,14 @@
 package org.folio.service.s3storage;
 
 import io.vertx.core.Future;
+import org.folio.rest.jaxrs.model.UserInfo;
 
 public interface MinioStorageService {
 
   /*
    *
    */
-  Future<String> getFileUploadUrl( String upLoadFileName, String tenantId);
+  Future<UserInfo> getFileUploadUrl(String upLoadFileName, String tenantId);
 
 
 }

--- a/src/main/java/org/folio/service/s3storage/MinioStorageService.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageService.java
@@ -6,7 +6,14 @@ import org.folio.rest.jaxrs.model.FileUploadInfo;
 public interface MinioStorageService {
 
   /*
+   * Gets upload url and key for a file upload
    *
+   * @param uploadFileName - name of file to be uploaded
+   * @param tenantId - tenant associated with this upload
+   *
+   * @return FileUploadInfo
+   *  url - presigned Url to S3 storage
+   *  key  - key for access to file on S3 storage
    */
   Future<FileUploadInfo> getFileUploadUrl(String upLoadFileName, String tenantId);
 

--- a/src/main/java/org/folio/service/s3storage/MinioStorageService.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageService.java
@@ -1,0 +1,13 @@
+package org.folio.service.s3storage;
+
+import io.vertx.core.Future;
+
+public interface MinioStorageService {
+
+  /*
+   *
+   */
+  Future<String> getFileUploadUrl( String upLoadFileName, String tenantId);
+
+
+}

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -1,58 +1,73 @@
 package org.folio.service.s3storage;
 
+import io.minio.http.Method;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import lombok.SneakyThrows;
 import org.folio.rest.jaxrs.model.FileUploadInfo;
+import org.folio.s3.client.FolioS3Client;
+import org.folio.s3.exception.S3ClientException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MinioStorageServiceImpl implements MinioStorageService {
 
-  @Autowired
   private FolioS3ClientFactory folioS3ClientFactory;
 
-  @Autowired
   private Vertx vertx;
 
-  @Value("${minio.bucket}")
-  private String bucket;
-
-  @SneakyThrows
-  public Future<FileUploadInfo> getFileUploadUrl(String upLoadFileName, String tenantId) {
-    Promise<FileUploadInfo> promise = Promise.promise();
-    var client = folioS3ClientFactory.getFolioS3Client();
-    var key = buildKey(tenantId, upLoadFileName);
-
-    vertx.executeBlocking(blockingFuture -> {
-      String url = null;
-      try {
-        url = client.getPresignedUrl(key);
-      } catch (Exception e) {
-        blockingFuture.fail(e);
-      }
-      blockingFuture.complete(url);
-    }, asyncResult -> {
-      if (asyncResult.failed()) {
-        promise.fail(asyncResult.cause());
-      } else {
-        String url = (String) asyncResult.result();
-        FileUploadInfo fileUpload = new FileUploadInfo();
-        fileUpload.setUrl(url);
-        fileUpload.setKey(key);
-        promise.complete(fileUpload);
-      }
-    });
-
-    return promise.future();
-
+  @Autowired
+  public MinioStorageServiceImpl(
+    FolioS3ClientFactory folioS3ClientFactory,
+    Vertx vertx
+  ) {
+    this.folioS3ClientFactory = folioS3ClientFactory;
+    this.vertx = vertx;
   }
 
-  private String buildKey(String tenantId, String fileName) {
-    String format = String.format("%s/%d-%s", tenantId, System.currentTimeMillis(), fileName);
-    return format;
+  public Future<FileUploadInfo> getFileUploadUrl(
+    String uploadFileName,
+    String tenantId
+  ) {
+    Promise<FileUploadInfo> promise = Promise.promise();
+    FolioS3Client client = folioS3ClientFactory.getFolioS3Client();
+
+    String key = buildKey(tenantId, uploadFileName);
+
+    vertx.executeBlocking(
+      (Promise<String> blockingFuture) -> {
+        String url = null;
+        try {
+          url = client.getPresignedUrl(key, Method.PUT);
+        } catch (S3ClientException e) {
+          blockingFuture.fail(e);
+        }
+        blockingFuture.complete(url);
+      },
+      (AsyncResult<String> asyncResult) -> {
+        if (asyncResult.failed()) {
+          promise.fail(asyncResult.cause());
+        } else {
+          String url = (String) asyncResult.result();
+          FileUploadInfo fileUpload = new FileUploadInfo();
+          fileUpload.setUrl(url);
+          fileUpload.setKey(key);
+          promise.complete(fileUpload);
+        }
+      }
+    );
+
+    return promise.future();
+  }
+
+  private static String buildKey(String tenantId, String fileName) {
+    return String.format(
+      "%s/%d-%s",
+      tenantId,
+      System.currentTimeMillis(),
+      fileName
+    );
   }
 }

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -50,7 +50,7 @@ public class MinioStorageServiceImpl implements MinioStorageService {
         if (asyncResult.failed()) {
           promise.fail(asyncResult.cause());
         } else {
-          String url = (String) asyncResult.result();
+          String url = asyncResult.result();
           FileUploadInfo fileUpload = new FileUploadInfo();
           fileUpload.setUrl(url);
           fileUpload.setKey(key);

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -4,7 +4,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import lombok.SneakyThrows;
-import org.folio.rest.jaxrs.model.UserInfo;
+import org.folio.rest.jaxrs.model.FileUploadInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -23,8 +23,8 @@ public class MinioStorageServiceImpl implements MinioStorageService {
   private String bucket;
 
   @SneakyThrows
-  public Future<UserInfo> getFileUploadUrl(String upLoadFileName, String tenantId) {
-    Promise<UserInfo> promise = Promise.promise();
+  public Future<FileUploadInfo> getFileUploadUrl(String upLoadFileName, String tenantId) {
+    Promise<FileUploadInfo> promise = Promise.promise();
     var client = folioS3ClientFactory.getFolioS3Client();
     //var key = buildPrefix(tenantId) + "/" + upLoadFileName;
     var key =  upLoadFileName;
@@ -48,9 +48,10 @@ public class MinioStorageServiceImpl implements MinioStorageService {
         promise.fail(asyncResult.cause());
       } else {
         String url = (String) asyncResult.result();
-        UserInfo user = new UserInfo();
-        user.setUserName(url);
-        promise.complete(user);
+        FileUploadInfo fileUpload = new FileUploadInfo();
+        fileUpload.setUrl(url);
+        fileUpload.setKey(key);
+        promise.complete(fileUpload);
       }
     });
 

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -4,10 +4,13 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import lombok.SneakyThrows;
+import org.folio.rest.jaxrs.model.UserInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.util.StringUtils;
+import org.springframework.stereotype.Service;
 
+
+@Service
 public class MinioStorageServiceImpl implements MinioStorageService {
 
   @Autowired
@@ -20,10 +23,11 @@ public class MinioStorageServiceImpl implements MinioStorageService {
   private String bucket;
 
   @SneakyThrows
-  public Future<String> getFileUploadUrl(String upLoadFileName, String tenantId) {
-    Promise<String> promise = Promise.promise();
+  public Future<UserInfo> getFileUploadUrl(String upLoadFileName, String tenantId) {
+    Promise<UserInfo> promise = Promise.promise();
     var client = folioS3ClientFactory.getFolioS3Client();
-    var key = buildPrefix(tenantId) + "/" + upLoadFileName;
+    //var key = buildPrefix(tenantId) + "/" + upLoadFileName;
+    var key =  upLoadFileName;
 
    /*
    if (!StringUtils.hasText(bucket)) {
@@ -44,7 +48,9 @@ public class MinioStorageServiceImpl implements MinioStorageService {
         promise.fail(asyncResult.cause());
       } else {
         String url = (String) asyncResult.result();
-        promise.complete(url);
+        UserInfo user = new UserInfo();
+        user.setUserName(url);
+        promise.complete(user);
       }
     });
 

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -1,0 +1,58 @@
+package org.folio.service.s3storage;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.StringUtils;
+
+public class MinioStorageServiceImpl implements MinioStorageService {
+
+  @Autowired
+  private FolioS3ClientFactory folioS3ClientFactory;
+
+  @Autowired
+  private Vertx vertx;
+
+  @Value("${minio.bucket}")
+  private String bucket;
+
+  @SneakyThrows
+  public Future<String> getFileUploadUrl(String upLoadFileName, String tenantId) {
+    Promise<String> promise = Promise.promise();
+    var client = folioS3ClientFactory.getFolioS3Client();
+    var key = buildPrefix(tenantId) + "/" + upLoadFileName;
+
+   /*
+   if (!StringUtils.hasText(bucket)) {
+       throw new Exception("Bucket not found");
+    }
+    */
+
+    vertx.executeBlocking(blockingFuture -> {
+      String url = null;
+      try {
+        url = client.getPresignedUrl(key);
+      } catch (Exception e) {
+        blockingFuture.fail(e);
+      }
+      blockingFuture.complete(url);
+    }, asyncResult -> {
+      if (asyncResult.failed()) {
+        promise.fail(asyncResult.cause());
+      } else {
+        String url = (String) asyncResult.result();
+        promise.complete(url);
+      }
+    });
+
+    return promise.future();
+
+  }
+
+  private String buildPrefix(String tenantId) {
+    return tenantId ;
+  }
+}

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-
 @Service
 public class MinioStorageServiceImpl implements MinioStorageService {
 
@@ -26,14 +25,7 @@ public class MinioStorageServiceImpl implements MinioStorageService {
   public Future<FileUploadInfo> getFileUploadUrl(String upLoadFileName, String tenantId) {
     Promise<FileUploadInfo> promise = Promise.promise();
     var client = folioS3ClientFactory.getFolioS3Client();
-    //var key = buildPrefix(tenantId) + "/" + upLoadFileName;
-    var key =  upLoadFileName;
-
-   /*
-   if (!StringUtils.hasText(bucket)) {
-       throw new Exception("Bucket not found");
-    }
-    */
+    var key = buildKey(tenantId, upLoadFileName);
 
     vertx.executeBlocking(blockingFuture -> {
       String url = null;
@@ -59,7 +51,8 @@ public class MinioStorageServiceImpl implements MinioStorageService {
 
   }
 
-  private String buildPrefix(String tenantId) {
-    return tenantId ;
+  private String buildKey(String tenantId, String fileName) {
+    String format = String.format("%s/%d-%s", tenantId, System.currentTimeMillis(), fileName);
+    return format;
   }
 }

--- a/src/main/resources/minio.properties
+++ b/src/main/resources/minio.properties
@@ -1,0 +1,6 @@
+minio.endpoint = ${AWS_URL:http://127.0.0.1:9000/}
+minio.region = ${AWS_REGION:}
+minio.bucket = ${AWS_BUCKET:}
+minio.accessKey = ${AWS_ACCESS_KEY_ID:}
+minio.secretKey = ${AWS_SECRET_ACCESS_KEY:}
+minio.awsSdk = ${AWS_SDK:}

--- a/src/test/java/org/folio/rest/UploadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/UploadUrlAPITest.java
@@ -1,0 +1,41 @@
+package org.folio.rest;
+
+import static org.hamcrest.Matchers.matchesRegex;
+
+import io.restassured.RestAssured;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(VertxUnitRunner.class)
+public class UploadUrlAPITest extends AbstractRestTest {
+
+  private static final String UPLOAD_URL_PATH = "/data-import/uploadUrl";
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testSuccessfulRequest() {
+    RestAssured
+      .given()
+      .spec(spec)
+      .when()
+      .queryParam("fileName", "test-name")
+      .get(UPLOAD_URL_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body(
+        "url",
+        matchesRegex(
+          "^http://127\\.0\\.0\\.1:9000/test-bucket/diku/\\d+-test-name\\?X.+$"
+        )
+      )
+      .body("key", matchesRegex("^diku/\\d+-test-name$"));
+  }
+}

--- a/src/test/java/org/folio/service/s3storage/FolioS3ClientFactoryTest.java
+++ b/src/test/java/org/folio/service/s3storage/FolioS3ClientFactoryTest.java
@@ -1,0 +1,63 @@
+package org.folio.service.s3storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+import org.folio.s3.client.AwsS3Client;
+import org.folio.s3.client.MinioS3Client;
+import org.folio.s3.client.S3ClientFactory;
+import org.folio.s3.client.S3ClientProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class FolioS3ClientFactoryTest {
+
+  @Mock
+  private MinioS3Client testMinioClient;
+
+  @Mock
+  private AwsS3Client testAwsClient;
+
+  @InjectMocks
+  private FolioS3ClientFactory folioS3ClientFactory;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testFolioS3ClientCreation() {
+    MockedStatic<S3ClientFactory> mock = Mockito.mockStatic(
+      S3ClientFactory.class
+    );
+
+    mock
+      .when(() -> S3ClientFactory.getS3Client(any(S3ClientProperties.class)))
+      .thenReturn(testMinioClient, testAwsClient);
+
+    assertEquals(
+      "Client is created on first run",
+      testMinioClient,
+      folioS3ClientFactory.getFolioS3Client()
+    );
+
+    assertEquals(
+      "Client is not recreated on second run",
+      testMinioClient,
+      folioS3ClientFactory.getFolioS3Client()
+    );
+
+    mock.verify(
+      () -> S3ClientFactory.getS3Client(any(S3ClientProperties.class)),
+      times(1)
+    );
+    mock.verifyNoMoreInteractions();
+  }
+}

--- a/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
+++ b/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
@@ -1,0 +1,111 @@
+package org.folio.service.s3storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+
+import io.minio.http.Method;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.rest.jaxrs.model.FileUploadInfo;
+import org.folio.s3.client.FolioS3Client;
+import org.folio.s3.exception.S3ClientException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(VertxUnitRunner.class)
+public class MinioStorageServiceTest {
+
+  private final Vertx vertx = Vertx.vertx();
+
+  @Mock
+  private FolioS3ClientFactory folioS3ClientFactory;
+
+  @Mock
+  private FolioS3Client folioS3Client;
+
+  private MinioStorageService minioStorageService;
+
+  @Before
+  public void setUp(TestContext context) {
+    vertx.exceptionHandler((err -> context.fail(err)));
+
+    MockitoAnnotations.openMocks(this);
+    this.minioStorageService =
+      new MinioStorageServiceImpl(folioS3ClientFactory, vertx);
+
+    Mockito
+      .when(folioS3ClientFactory.getFolioS3Client())
+      .thenReturn(folioS3Client);
+  }
+
+  @Test
+  public void testSuccessful(TestContext context) {
+    Async async = context.async();
+
+    Mockito
+      .when(folioS3Client.getPresignedUrl(anyString(), eq(Method.PUT)))
+      .thenReturn("url");
+
+    Future<FileUploadInfo> result = minioStorageService.getFileUploadUrl(
+      "test-file",
+      "test-tenant"
+    );
+
+    result.onFailure(_err -> context.fail("getFileUploadUrl should not fail"));
+    result.onSuccess(fileInfo -> {
+      Mockito.verify(folioS3ClientFactory, times(1)).getFolioS3Client();
+      Mockito
+        .verify(folioS3Client, times(1))
+        .getPresignedUrl(fileInfo.getKey(), Method.PUT);
+      Mockito.verifyNoMoreInteractions(folioS3ClientFactory);
+      Mockito.verifyNoMoreInteractions(folioS3Client);
+
+      assertEquals("Presigned URL is returned", "url", fileInfo.getUrl());
+      assertTrue(
+        "Key format is correct",
+        fileInfo.getKey().matches("test-tenant/\\d*-test-file")
+      );
+      async.complete();
+    });
+  }
+
+  @Test
+  public void testFailure(TestContext context) {
+    Async async = context.async();
+
+    S3ClientException exception = new S3ClientException("test exception");
+
+    Mockito
+      .when(folioS3Client.getPresignedUrl(anyString(), eq(Method.PUT)))
+      .thenThrow(exception);
+
+    Future<FileUploadInfo> result = minioStorageService.getFileUploadUrl(
+      "test-file",
+      "test-tenant"
+    );
+
+    result.onSuccess(_result -> context.fail("getFileUploadUrl should fail"));
+    result.onFailure(err -> {
+      Mockito.verify(folioS3ClientFactory, times(1)).getFolioS3Client();
+      Mockito
+        .verify(folioS3Client, times(1))
+        .getPresignedUrl(anyString(), eq(Method.PUT));
+      Mockito.verifyNoMoreInteractions(folioS3ClientFactory);
+      Mockito.verifyNoMoreInteractions(folioS3Client);
+
+      assertSame("Fails with getPresignedUrl exception", exception, err);
+      async.complete();
+    });
+  }
+}

--- a/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
+++ b/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
@@ -74,7 +74,7 @@ public class MinioStorageServiceTest {
       assertEquals("Presigned URL is returned", "url", fileInfo.getUrl());
       assertTrue(
         "Key format is correct",
-        fileInfo.getKey().matches("test-tenant/\\d*-test-file")
+        fileInfo.getKey().matches("^test-tenant/\\d*-test-file$")
       );
       async.complete();
     });

--- a/src/test/resources/minio.properties
+++ b/src/test/resources/minio.properties
@@ -1,0 +1,6 @@
+minio.endpoint = http://127.0.0.1:9000/
+minio.region = test-region
+minio.bucket = test-bucket
+minio.accessKey = test-access-key
+minio.secretKey = test-secret-key
+minio.awsSdk = false


### PR DESCRIPTION
## Purpose
As part of the data import improvement project, we want to upload directly to S3-like storage from the frontend.  This requires obtaining a presigned URL and exposing an endpoint to obtain this URL, which was added as `GET /uploadUrl` (see https://github.com/folio-org/folio-s3-client/pull/11 for the accompanying changes in `folio-s3-client`).

## Approach
This adds a new endpoint `GET /uploadUrl` and entity `FileUploadInfo` to contain data that allows the frontend client to upload directly to S3.  To accomplish this, infrastructure was added to interface with the FOLIO S3 client.