### PR TITLE
MODDATAIMP-857: Add multipart compatibility to /uploadUrl endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -275,7 +275,7 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/data-import/uploadUrl/continue",
+          "pathPattern": "/data-import/uploadUrl/subsequent",
           "permissionsRequired": ["data-import.uploadUrl.get"]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -272,6 +272,11 @@
           "methods": ["GET"],
           "pathPattern": "/data-import/uploadUrl",
           "permissionsRequired": ["data-import.uploadUrl.get"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/data-import/uploadUrl/continue",
+          "permissionsRequired": ["data-import.uploadUrl.get"]
         }
       ]
     },

--- a/pom.xml
+++ b/pom.xml
@@ -122,9 +122,9 @@
       <version>2.6</version>
     </dependency>
     <dependency>
-      <groupId>com.github.folio-org</groupId>
+      <groupId>org.folio</groupId>
       <artifactId>folio-s3-client</artifactId>
-      <version>FOLS3CL-13-SNAPSHOT</version>
+      <version>${folio-s3-client.version}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -600,10 +600,6 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven Repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
-    </repository>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://www.jitpack.io</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,9 +122,9 @@
       <version>2.6</version>
     </dependency>
     <dependency>
-      <groupId>org.folio</groupId>
+      <groupId>com.github.folio-org</groupId>
       <artifactId>folio-s3-client</artifactId>
-      <version>${folio-s3-client.version}</version>
+      <version>FOLS3CL-13-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -588,6 +588,10 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven Repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
+    </repository>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://www.jitpack.io</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,19 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.18.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>1.18.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
       <version>1.18.3</version>
       <scope>test</scope>
     </dependency>

--- a/ramls/dataImport.raml
+++ b/ramls/dataImport.raml
@@ -276,7 +276,7 @@ resourceTypes:
           body:
             text/plain:
               example: "Internal server error"
-  /uploadUrl/continue:
+  /uploadUrl/subsequent:
     get:
       description: Get a presigned upload url for later parts of a file
       queryParameters:

--- a/ramls/dataImport.raml
+++ b/ramls/dataImport.raml
@@ -256,11 +256,41 @@ resourceTypes:
               example: "Internal server error"
   /uploadUrl:
     get:
-      description: Get an upload url
+      description: Get a presigned upload url for the first part of a file
       queryParameters:
         fileName:
-          description: "fileName parameter"
+          description: "The name of the file that will be uploaded"
           required: true
+      responses:
+        200:
+          body:
+            application/json:
+              type: fileUploadInfo
+        400:
+          description: "Bad request"
+          body:
+            text/plain:
+              example: "Bad request"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
+  /uploadUrl/continue:
+    get:
+      description: Get a presigned upload url for later parts of a file
+      queryParameters:
+        key:
+          description: "The key that will be uploaded to on S3"
+          required: true
+        uploadId:
+          description: "The upload ID"
+          required: true
+        partNumber:
+          description: "The part number, postitive integers beginning at two (part 1 is uploaded with /uploadUrl)"
+          required: true
+          type: integer
+          minimum: 2
       responses:
         200:
           body:

--- a/ramls/fileUploadInfo.json
+++ b/ramls/fileUploadInfo.json
@@ -11,10 +11,11 @@
     "key": {
       "description": "Key for file upload on S3 storage",
       "type": "string"
+    },
+    "uploadId": {
+      "description": "Multipart upload ID",
+      "type": "string"
     }
   },
-  "required": [
-    "url",
-    "key"
-  ]
+  "required": ["url", "key", "uploadId"]
 }

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -433,7 +433,7 @@ public class DataImportImpl implements DataImport {
   public void getDataImportUploadUrl(String fileName, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        LOGGER.debug("getDataImportUploadUrl:: getting upload url");
+        LOGGER.debug("getDataImportUploadUrl:: getting upload url for filename {}", fileName);
         minioStorageService.getFileUploadFirstPartUrl(fileName, tenantId)
           .map(GetDataImportUploadUrlResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
@@ -451,7 +451,12 @@ public class DataImportImpl implements DataImport {
                                      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        LOGGER.debug("getDataImportUploadUrlSubsequent:: getting subsequent upload url");
+        LOGGER.debug(
+          "getDataImportUploadUrlSubsequent:: getting subsequent upload url, part #{} of key {} (upload ID {})",
+          partNumber,
+          key,
+          uploadId
+        );
         minioStorageService.getFileUploadPartUrl(key, uploadId, partNumber)
           .map(GetDataImportUploadUrlSubsequentResponse::respond200WithApplicationJson)
           .map(Response.class::cast)

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -447,13 +447,13 @@ public class DataImportImpl implements DataImport {
   }
 
   @Override
-  public void getDataImportUploadUrlContinue(String key, String uploadId, int partNumber, Map<String, String> okapiHeaders,
+  public void getDataImportUploadUrlSubsequent(String key, String uploadId, int partNumber, Map<String, String> okapiHeaders,
                                      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        LOGGER.debug("getDataImportUploadUrlContinue:: getting continued upload url");
+        LOGGER.debug("getDataImportUploadUrlSubsequent:: getting subsequent upload url");
         minioStorageService.getFileUploadPartUrl(key, uploadId, partNumber)
-          .map(GetDataImportUploadUrlContinueResponse::respond200WithApplicationJson)
+          .map(GetDataImportUploadUrlSubsequentResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .onComplete(asyncResultHandler);

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -434,8 +434,26 @@ public class DataImportImpl implements DataImport {
     vertxContext.runOnContext(v -> {
       try {
         LOGGER.debug("getDataImportUploadUrl:: getting upload url");
-        minioStorageService.getFileUploadUrl(fileName, tenantId)
+        minioStorageService.getFileUploadFirstPartUrl(fileName, tenantId)
           .map(GetDataImportUploadUrlResponse::respond200WithApplicationJson)
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .onComplete(asyncResultHandler);
+      } catch (Exception e) {
+        LOGGER.warn("getDataImportUploadUrl:: Failed to get upload url", e);
+        asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
+      }
+    });
+  }
+
+  @Override
+  public void getDataImportUploadUrlContinue(String key, String uploadId, int partNumber, Map<String, String> okapiHeaders,
+                                     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    vertxContext.runOnContext(v -> {
+      try {
+        LOGGER.debug("getDataImportUploadUrlContinue:: getting continued upload url");
+        minioStorageService.getFileUploadPartUrl(key, uploadId, partNumber)
+          .map(GetDataImportUploadUrlContinueResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .onComplete(asyncResultHandler);

--- a/src/main/java/org/folio/service/s3storage/MinioStorageService.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageService.java
@@ -1,21 +1,49 @@
 package org.folio.service.s3storage;
 
 import io.vertx.core.Future;
+import javax.validation.constraints.NotNull;
 import org.folio.rest.jaxrs.model.FileUploadInfo;
 
 public interface MinioStorageService {
-  /*
+  /**
    * Gets upload url and key for a file upload
    *
    * @param uploadFileName - name of file to be uploaded
    * @param tenantId - tenant associated with this upload
-   *
+   * @param uploadId - id of upload, if this upload will continue on a previously
+   * started multipart upload
+   * @param partNumber - the part number, starting at 1. If uploadId=null, this
+   * must be 1.
    * @return FileUploadInfo
-   *  url - presigned Url to S3 storage
-   *  key - key for access to file on S3 storage
+   * <ul>
+   *   <li>url: presigned Url to S3 storage</li>
+   *   <li>key: key for access to file on S3 storage</li>
+   *   <li>uploadId: multipart upload ID</li>
+   * </ul>
    */
-  Future<FileUploadInfo> getFileUploadUrl(
+  Future<FileUploadInfo> getFileUploadFirstPartUrl(
     String uploadFileName,
     String tenantId
+  );
+
+  /**
+   * Gets upload url and key for a file upload
+   *
+   * @param key - the key to access the file on S3 storage, as generated with
+   *   {@link #getFileFirstPartUploadUrl}
+   * @param uploadId - id of upload from previous calls to {@link #getFileFirstPartUploadUrl}
+   * @param partNumber - the part number, starting at 2 (part number 1 will be
+   *   provided by {@link #getFileFirstPartUploadUrl})
+   * @return FileUploadInfo
+   * <ul>
+   *   <li>url: presigned URL to S3 storage</li>
+   *   <li>key: key for access to file on S3 storage</li>
+   *   <li>uploadId: multipart upload ID</li>
+   * </ul>
+   */
+  Future<FileUploadInfo> getFileUploadPartUrl(
+    String key,
+    @NotNull String uploadId,
+    int partNumber
   );
 }

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -4,12 +4,14 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import lombok.extern.log4j.Log4j2;
 import org.folio.rest.jaxrs.model.FileUploadInfo;
 import org.folio.s3.client.FolioS3Client;
 import org.folio.s3.exception.S3ClientException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+@Log4j2
 @Service
 public class MinioStorageServiceImpl implements MinioStorageService {
 
@@ -38,7 +40,9 @@ public class MinioStorageServiceImpl implements MinioStorageService {
     vertx.executeBlocking(
       (Promise<String> blockingFuture) -> {
         try {
-          blockingFuture.complete(client.initiateMultipartUpload(key));
+          String uploadId = client.initiateMultipartUpload(key);
+          log.info("Created upload ID {} for key {}", uploadId, key);
+          blockingFuture.complete(uploadId);
         } catch (S3ClientException e) {
           blockingFuture.fail(e);
         }

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -4,16 +4,18 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import lombok.extern.log4j.Log4j2;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.FileUploadInfo;
 import org.folio.s3.client.FolioS3Client;
 import org.folio.s3.exception.S3ClientException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-@Log4j2
 @Service
 public class MinioStorageServiceImpl implements MinioStorageService {
+
+  private static final Logger LOGGER = LogManager.getLogger();
 
   private FolioS3ClientFactory folioS3ClientFactory;
 
@@ -41,7 +43,7 @@ public class MinioStorageServiceImpl implements MinioStorageService {
       (Promise<String> blockingFuture) -> {
         try {
           String uploadId = client.initiateMultipartUpload(key);
-          log.info("Created upload ID {} for key {}", uploadId, key);
+          LOGGER.info("Created upload ID {} for key {}", uploadId, key);
           blockingFuture.complete(uploadId);
         } catch (S3ClientException e) {
           blockingFuture.fail(e);
@@ -72,6 +74,12 @@ public class MinioStorageServiceImpl implements MinioStorageService {
     vertx.executeBlocking(
       (Promise<String> blockingFuture) -> {
         try {
+          LOGGER.info(
+            "Getting presigned URL for part {} of key {}/upload ID {}",
+            partNumber,
+            key,
+            uploadId
+          );
           blockingFuture.complete(
             client.getPresignedMultipartUploadUrl(key, uploadId, partNumber)
           );

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -66,7 +66,7 @@ public abstract class AbstractRestTest {
   public static final String TEST_MODULE_VERSION = "-1.0.0";
   protected static int port;
   private static String useExternalDatabase;
-  protected static Vertx vertx;
+  private static Vertx vertx;
   protected static final String TENANT_ID = "diku";
   protected static final String TOKEN = "token";
   protected static RequestSpecification spec;

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -15,6 +15,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import lombok.extern.log4j.Log4j2;
 import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.client.TenantClient;
@@ -29,10 +30,16 @@ import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.ModuleName;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.s3.client.S3ClientFactory;
+import org.folio.s3.client.S3ClientProperties;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -49,6 +56,8 @@ import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
 /**
  * Abstract test for the REST API testing needs.
  */
+@Log4j2
+@Testcontainers
 public abstract class AbstractRestTest {
 
   private static final String FILE_EXTENSIONS_TABLE = "file_extensions";
@@ -57,7 +66,7 @@ public abstract class AbstractRestTest {
   public static final String TEST_MODULE_VERSION = "-1.0.0";
   protected static int port;
   private static String useExternalDatabase;
-  private static Vertx vertx;
+  protected static Vertx vertx;
   protected static final String TENANT_ID = "diku";
   protected static final String TOKEN = "token";
   protected static RequestSpecification spec;
@@ -68,6 +77,7 @@ public abstract class AbstractRestTest {
   private static final String OKAPI_URL_ENV = "OKAPI_URL";
   private static final int PORT = NetworkUtils.nextFreePort();
   protected static final String OKAPI_URL = "http://localhost:" + PORT;
+  private static final String MINIO_BUCKET = "test-bucket";
 
   private static final String GET_USER_URL = "/users?query=id==";
 
@@ -124,6 +134,12 @@ public abstract class AbstractRestTest {
 
   public static EmbeddedKafkaCluster kafkaCluster;
 
+  @Container
+  private static final LocalStackContainer localStackContainer = new LocalStackContainer(
+    DockerImageName.parse("localstack/localstack:0.11.3")
+  )
+    .withServices(LocalStackContainer.Service.S3);
+
   @Rule
   public WireMockRule mockServer = new WireMockRule(
     WireMockConfiguration.wireMockConfig()
@@ -134,6 +150,8 @@ public abstract class AbstractRestTest {
   public static void setUpClass(final TestContext context) throws Exception {
     Async async = context.async();
     vertx = Vertx.vertx();
+
+    log.info("Starting Kafka...");
     kafkaCluster = provisionWith(defaultClusterConfig());
     kafkaCluster.start();
     String[] hostAndPort = kafkaCluster.getBrokerList().split(":");
@@ -142,6 +160,27 @@ public abstract class AbstractRestTest {
     System.setProperty(KAFKA_PORT, hostAndPort[1]);
     System.setProperty(KAFKA_MAX_REQUEST_SIZE, "1048576");
     System.setProperty(OKAPI_URL_ENV, OKAPI_URL);
+
+    log.info("Starting LocalStack/S3...");
+    localStackContainer.start();
+    log.info(localStackContainer.getEndpoint().toString());
+    System.setProperty("minio.endpoint", localStackContainer.getEndpoint().toString());
+    System.setProperty("minio.region", localStackContainer.getRegion());
+    System.setProperty("minio.accessKey", localStackContainer.getAccessKey());
+    System.setProperty("minio.secretKey", localStackContainer.getSecretKey());
+    System.setProperty("minio.bucket", MINIO_BUCKET);
+    System.setProperty("minio.awsSdk", "false");
+    S3ClientFactory.getS3Client(
+      S3ClientProperties
+        .builder()
+        .endpoint(localStackContainer.getEndpoint().toString())
+        .accessKey(localStackContainer.getAccessKey())
+        .secretKey(localStackContainer.getSecretKey())
+        .bucket(MINIO_BUCKET)
+        .awsSdk(false)
+        .region(localStackContainer.getRegion())
+        .build()
+    ).createBucketIfNotExists();
 
     port = NetworkUtils.nextFreePort();
     String okapiUrl = "http://localhost:" + port;

--- a/src/test/java/org/folio/rest/UploadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/UploadUrlAPITest.java
@@ -37,9 +37,7 @@ public class UploadUrlAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_OK)
       .body(
         "url",
-        matchesRegex(
-          "^http://127\\.0\\.0\\.1:\\d+/test-bucket/diku/\\d+-test-name\\?.*&partNumber=1.*$"
-        )
+        matchesRegex("/test-bucket/diku/\\d+-test-name\\?.*&partNumber=1.*$")
       )
       .body("key", matchesRegex("^diku/\\d+-test-name$"))
       .body("uploadId", notNullValue());
@@ -59,9 +57,7 @@ public class UploadUrlAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_OK)
       .body(
         "url",
-        matchesRegex(
-          "^http://127\\.0\\.0\\.1:\\d+/test-bucket/diku/\\d+-test-name\\?.*&partNumber=5.*$"
-        )
+        matchesRegex("/test-bucket/diku/1234-test-name\\?.*&partNumber=5.*$")
       )
       .body("key", is(equalTo("diku/1234-test-name")))
       .body("uploadId", is(equalTo("upload-id-here")));

--- a/src/test/java/org/folio/rest/UploadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/UploadUrlAPITest.java
@@ -20,7 +20,7 @@ public class UploadUrlAPITest extends AbstractRestTest {
 
   private static final String UPLOAD_URL_PATH = "/data-import/uploadUrl";
   private static final String UPLOAD_URL_CONTINUE_PATH =
-    "/data-import/uploadUrl/continue";
+    "/data-import/uploadUrl/subsequent";
 
   @Before
   public void setUp() {
@@ -49,7 +49,7 @@ public class UploadUrlAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void testSuccessfulLaterRequest() {
+  public void testSuccessfulSubsequentRequest() {
     RestAssured
       .given()
       .spec(spec)

--- a/src/test/java/org/folio/rest/UploadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/UploadUrlAPITest.java
@@ -1,5 +1,7 @@
 package org.folio.rest;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
@@ -37,9 +39,12 @@ public class UploadUrlAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_OK)
       .body(
         "url",
-        matchesRegex("/test-bucket/diku/\\d+-test-name\\?.*&partNumber=1.*$")
+        allOf(
+          matchesRegex(".*/test-bucket/diku/\\d+-test-name.*"),
+          containsString("partNumber=1")
+        )
       )
-      .body("key", matchesRegex("^diku/\\d+-test-name$"))
+      .body("key", matchesRegex("^diku/[0-9]+-test-name$"))
       .body("uploadId", notNullValue());
   }
 
@@ -57,7 +62,11 @@ public class UploadUrlAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_OK)
       .body(
         "url",
-        matchesRegex("/test-bucket/diku/1234-test-name\\?.*&partNumber=5.*$")
+        allOf(
+          containsString("/test-bucket/diku/1234-test-name"),
+          containsString("partNumber=5"),
+          containsString("uploadId=upload-id-here")
+        )
       )
       .body("key", is(equalTo("diku/1234-test-name")))
       .body("uploadId", is(equalTo("upload-id-here")));

--- a/src/test/java/org/folio/rest/UploadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/UploadUrlAPITest.java
@@ -1,6 +1,7 @@
 package org.folio.rest;
 
 import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.notNullValue;
 
 import io.restassured.RestAssured;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -36,6 +37,7 @@ public class UploadUrlAPITest extends AbstractRestTest {
           "^http://127\\.0\\.0\\.1:9000/test-bucket/diku/\\d+-test-name\\?X.+$"
         )
       )
-      .body("key", matchesRegex("^diku/\\d+-test-name$"));
+      .body("key", matchesRegex("^diku/\\d+-test-name$"))
+      .body("uploadId", notNullValue());
   }
 }

--- a/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
+++ b/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 
-import io.minio.http.Method;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
@@ -50,28 +49,49 @@ public class MinioStorageServiceTest {
   }
 
   @Test
-  public void testSuccessful(TestContext context) {
+  public void testFirstPartSuccessful(TestContext context) {
     Async async = context.async();
 
     Mockito
-      .when(folioS3Client.getPresignedUrl(anyString(), eq(Method.PUT)))
-      .thenReturn("url");
+      .when(folioS3Client.initiateMultipartUpload(anyString()))
+      .thenReturn("upload-id");
+    Mockito
+      .when(
+        folioS3Client.getPresignedMultipartUploadUrl(
+          anyString(),
+          eq("upload-id"),
+          eq(1)
+        )
+      )
+      .thenReturn("upload-url");
 
-    Future<FileUploadInfo> result = minioStorageService.getFileUploadUrl(
+    Future<FileUploadInfo> result = minioStorageService.getFileUploadFirstPartUrl(
       "test-file",
       "test-tenant"
     );
 
-    result.onFailure(_err -> context.fail("getFileUploadUrl should not fail"));
+    result.onFailure(_err ->
+      context.fail("getFileUploadFirstPartUrl should not fail")
+    );
     result.onSuccess(fileInfo -> {
-      Mockito.verify(folioS3ClientFactory, times(1)).getFolioS3Client();
       Mockito
         .verify(folioS3Client, times(1))
-        .getPresignedUrl(fileInfo.getKey(), Method.PUT);
-      Mockito.verifyNoMoreInteractions(folioS3ClientFactory);
+        .initiateMultipartUpload(fileInfo.getKey());
+      Mockito
+        .verify(folioS3Client, times(1))
+        .getPresignedMultipartUploadUrl(fileInfo.getKey(), "upload-id", 1);
       Mockito.verifyNoMoreInteractions(folioS3Client);
 
-      assertEquals("Presigned URL is returned", "url", fileInfo.getUrl());
+      assertEquals(
+        "Presigned URL is returned",
+        "upload-url",
+        fileInfo.getUrl()
+      );
+      assertEquals(
+        "Upload ID is returned",
+        "upload-id",
+        fileInfo.getUploadId()
+      );
       assertTrue(
         "Key format is correct",
         fileInfo.getKey().matches("^test-tenant/\\d*-test-file$")
@@ -81,30 +101,119 @@ public class MinioStorageServiceTest {
   }
 
   @Test
-  public void testFailure(TestContext context) {
+  public void testFirstPartFailure(TestContext context) {
     Async async = context.async();
 
     S3ClientException exception = new S3ClientException("test exception");
 
     Mockito
-      .when(folioS3Client.getPresignedUrl(anyString(), eq(Method.PUT)))
+      .when(folioS3Client.initiateMultipartUpload(anyString()))
       .thenThrow(exception);
 
-    Future<FileUploadInfo> result = minioStorageService.getFileUploadUrl(
+    Future<FileUploadInfo> result = minioStorageService.getFileUploadFirstPartUrl(
       "test-file",
       "test-tenant"
     );
 
-    result.onSuccess(_result -> context.fail("getFileUploadUrl should fail"));
+    result.onSuccess(_result ->
+      context.fail("getFileUploadFirstPartUrl should fail")
+    );
     result.onFailure(err -> {
-      Mockito.verify(folioS3ClientFactory, times(1)).getFolioS3Client();
       Mockito
         .verify(folioS3Client, times(1))
-        .getPresignedUrl(anyString(), eq(Method.PUT));
-      Mockito.verifyNoMoreInteractions(folioS3ClientFactory);
+        .initiateMultipartUpload(anyString());
       Mockito.verifyNoMoreInteractions(folioS3Client);
 
-      assertSame("Fails with getPresignedUrl exception", exception, err);
+      assertSame("Fails with correct exception", exception, err);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void testFirstPartNestedFailure(TestContext context) {
+    Async async = context.async();
+
+    S3ClientException exception = new S3ClientException("test exception");
+
+    Mockito
+      .when(folioS3Client.initiateMultipartUpload(anyString()))
+      .thenReturn("upload-id");
+    Mockito
+      .when(
+        folioS3Client.getPresignedMultipartUploadUrl(
+          anyString(),
+          eq("upload-id"),
+          eq(1)
+        )
+      )
+      .thenThrow(exception);
+
+    Future<FileUploadInfo> result = minioStorageService.getFileUploadFirstPartUrl(
+      "test-file",
+      "test-tenant"
+    );
+
+    result.onSuccess(_result ->
+      context.fail("getFileUploadFirstPartUrl should fail")
+    );
+    result.onFailure(err -> {
+      Mockito
+        .verify(folioS3Client, times(1))
+        .initiateMultipartUpload(anyString());
+      Mockito
+        .verify(folioS3Client, times(1))
+        .getPresignedMultipartUploadUrl(anyString(), eq("upload-id"), eq(1));
+      Mockito.verifyNoMoreInteractions(folioS3Client);
+
+      assertSame("Fails with correct exception", exception, err);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void testLaterPartSuccessful(TestContext context) {
+    Async async = context.async();
+
+    Mockito
+      .when(
+        folioS3Client.getPresignedMultipartUploadUrl(
+          "test-key",
+          "upload-id",
+          100
+        )
+      )
+      .thenReturn("upload-url-100");
+
+    Future<FileUploadInfo> result = minioStorageService.getFileUploadPartUrl(
+      "test-key",
+      "upload-id",
+      100
+    );
+
+    result.onFailure(_err ->
+      context.fail("getFileUploadPartUrl should not fail")
+    );
+    result.onSuccess(fileInfo -> {
+      Mockito
+        .verify(folioS3Client, times(1))
+        .getPresignedMultipartUploadUrl(fileInfo.getKey(), "upload-id", 100);
+      Mockito.verifyNoMoreInteractions(folioS3Client);
+
+      assertEquals(
+        "Presigned URL is returned",
+        "upload-url-100",
+        fileInfo.getUrl()
+      );
+      assertEquals(
+        "Upload ID is returned",
+        "upload-id",
+        fileInfo.getUploadId()
+      );
+      assertEquals(
+        "Key did not change is correct",
+        fileInfo.getKey(),
+        "test-key"
+      );
       async.complete();
     });
   }

--- a/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
+++ b/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
@@ -209,11 +209,7 @@ public class MinioStorageServiceTest {
         "upload-id",
         fileInfo.getUploadId()
       );
-      assertEquals(
-        "Key did not change is correct",
-        fileInfo.getKey(),
-        "test-key"
-      );
+      assertEquals("Key did not change", "test-key", fileInfo.getKey());
       async.complete();
     });
   }

--- a/src/test/resources/minio.properties
+++ b/src/test/resources/minio.properties
@@ -1,6 +1,0 @@
-minio.endpoint = http://127.0.0.1:9000/
-minio.region = test-region
-minio.bucket = test-bucket
-minio.accessKey = test-access-key
-minio.secretKey = test-secret-key
-minio.awsSdk = false


### PR DESCRIPTION
# [Jira MODDATAIMP-857](https://issues.folio.org/browse/MODDATAIMP-857)

## Purpose
Update the existing `/uploadUrl` endpoint to create a multipart upload; add a new endpoint to get presigned URLs for future parts.

## Approach
This updates the `MinioStorageService` methods to use multipart.  For testing, `testcontainers` with `LocalStack` was added, which emulates minio/S3.  I found another option for `minio` that was used by `mod-data-export-worker`, however, it relied on Spring/Spring Boot, so I decided `testcontainers` was the best solution.
