### PR TITLE
Moddataimp 874 implement api to combine s3 multi part uploads

### DIFF
--- a/ramls/dataImport.raml
+++ b/ramls/dataImport.raml
@@ -33,7 +33,7 @@ types:
   dataImportInitConfig: !include raml-storage/schemas/common/dataImportInitConfig.json
   fileUploadInfo: !include fileUploadInfo.json
   splitStatus: !include raml-storage/schemas/dto/splitStatus.json
-
+  assembleFileDto: !include raml-storage/schemas/dto/assembleFileDto.json
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml
   language: !include raml-storage/raml-util/traits/language.raml
@@ -299,6 +299,25 @@ resourceTypes:
           body:
             application/json:
               type: fileUploadInfo
+        400:
+          description: "Bad request"
+          body:
+            text/plain:
+              example: "Bad request"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
+  /assembleStorageFile:
+    post:
+      description: Assemble the large file uploaded to storage by the UI
+      is: [validate]
+      body:
+        application/json:
+          type: assembleFileDto
+      responses:
+        204:
         400:
           description: "Bad request"
           body:

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -501,7 +501,7 @@ public class DataImportImpl implements DataImport {
           entity.getKey()
         );
         minioStorageService.completeMultipartFileUpload(entity.getKey(),  entity.getUploadId(),entity.getTags())
-          .map(  completed -> completed ? PostDataImportAssembleStorageFileResponse.respond204() : PostDataImportAssembleStorageFileResponse.respond400WithTextPlain("Failed to assemble Data Import upload file") )
+          .map(  completed -> Boolean.TRUE.equals(completed) ? PostDataImportAssembleStorageFileResponse.respond204() : PostDataImportAssembleStorageFileResponse.respond400WithTextPlain("Failed to assemble Data Import upload file") )
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .onComplete(asyncResultHandler);

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -15,6 +15,7 @@ import org.folio.dataimport.util.ExceptionHelper;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.annotations.Stream;
+import org.folio.rest.jaxrs.model.AssembleFileDto;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.FileDefinition;
@@ -490,6 +491,27 @@ public class DataImportImpl implements DataImport {
     });
     
   }
+  @Override
+  public void postDataImportAssembleStorageFile(AssembleFileDto entity, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    vertxContext.runOnContext(v -> {
+      try {
+        LOGGER.debug(
+          "postDataImportAssembleStorageFile:: Assemble Storage File to complete upload",
+          entity.getKey()
+        );
+        minioStorageService.completeMultipartFileUpload(entity.getKey(),  entity.getUploadId(),entity.getTags())
+          .map( PostDataImportAssembleStorageFileResponse::respond204)
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .onComplete(asyncResultHandler);
+      } catch (Exception e) {
+        LOGGER.warn("getDataImportUploadUrl:: Failed to get upload url", e);
+        asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
+      }
+    });
+    
+  }
   /**
    * Validate {@link FileExtension} before save or update
    *
@@ -537,6 +559,8 @@ public class DataImportImpl implements DataImport {
     byte[] decodedBytes = Base64.getDecoder().decode(strEncoded);
     return new String(decodedBytes, StandardCharsets.UTF_8);
   }
+
+
 
 
 }

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -497,7 +497,7 @@ public class DataImportImpl implements DataImport {
     vertxContext.runOnContext(v -> {
       try {
         LOGGER.debug(
-          "postDataImportAssembleStorageFile:: Assemble Storage File to complete upload",
+          "postDataImportAssembleStorageFile:: Assemble Storage File to complete upload {}",
           entity.getKey()
         );
         minioStorageService.completeMultipartFileUpload(entity.getKey(),  entity.getUploadId(),entity.getTags())

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -501,7 +501,7 @@ public class DataImportImpl implements DataImport {
           entity.getKey()
         );
         minioStorageService.completeMultipartFileUpload(entity.getKey(),  entity.getUploadId(),entity.getTags())
-          .map(  deleted -> deleted ? PostDataImportAssembleStorageFileResponse.respond204() : PostDataImportAssembleStorageFileResponse.respond500WithTextPlain("Failed to assemble Data Import upload file") )
+          .map(  completed -> completed ? PostDataImportAssembleStorageFileResponse.respond204() : PostDataImportAssembleStorageFileResponse.respond500WithTextPlain("Failed to assemble Data Import upload file") )
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .onComplete(asyncResultHandler);

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -506,7 +506,7 @@ public class DataImportImpl implements DataImport {
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .onComplete(asyncResultHandler);
       } catch (Exception e) {
-        LOGGER.warn("getDataImportUploadUrl:: Failed to get upload url", e);
+        LOGGER.warn("getDataImportUploadUrl:: Failed to assemble file upload", e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
       }
     });

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -501,7 +501,7 @@ public class DataImportImpl implements DataImport {
           entity.getKey()
         );
         minioStorageService.completeMultipartFileUpload(entity.getKey(),  entity.getUploadId(),entity.getTags())
-          .map(  completed -> completed ? PostDataImportAssembleStorageFileResponse.respond204() : PostDataImportAssembleStorageFileResponse.respond500WithTextPlain("Failed to assemble Data Import upload file") )
+          .map(  completed -> completed ? PostDataImportAssembleStorageFileResponse.respond204() : PostDataImportAssembleStorageFileResponse.respond400WithTextPlain("Failed to assemble Data Import upload file") )
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .onComplete(asyncResultHandler);

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -501,7 +501,7 @@ public class DataImportImpl implements DataImport {
           entity.getKey()
         );
         minioStorageService.completeMultipartFileUpload(entity.getKey(),  entity.getUploadId(),entity.getTags())
-          .map( PostDataImportAssembleStorageFileResponse::respond204)
+          .map(  deleted -> deleted ? PostDataImportAssembleStorageFileResponse.respond204() : PostDataImportAssembleStorageFileResponse.respond500WithTextPlain("Failed to assemble Data Import upload file") )
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .onComplete(asyncResultHandler);

--- a/src/main/java/org/folio/service/s3storage/MinioStorageService.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageService.java
@@ -1,6 +1,9 @@
 package org.folio.service.s3storage;
 
 import io.vertx.core.Future;
+
+import java.util.List;
+
 import javax.validation.constraints.NotNull;
 import org.folio.rest.jaxrs.model.FileUploadInfo;
 
@@ -46,4 +49,6 @@ public interface MinioStorageService {
     @NotNull String uploadId,
     int partNumber
   );
+  
+  Future<Boolean> completeMultipartFileUpload(String key, String uploadId, List<String> etags);
 }

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -6,7 +6,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 import java.util.List;
-import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -4,6 +4,10 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+
+import java.util.List;
+import java.util.UUID;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.FileUploadInfo;
@@ -103,7 +107,25 @@ public class MinioStorageServiceImpl implements MinioStorageService {
 
     return promise.future();
   }
+  public Future<Boolean> completeMultipartFileUpload(String path,String uploadId,List<String> partEtags ) {
+    Promise<Boolean> promise = Promise.promise();
+    FolioS3Client client = folioS3ClientFactory.getFolioS3Client();
 
+    vertx.executeBlocking(
+        (Promise<String> blockingFuture) -> {
+      try {
+        
+            client.completeMultipartUpload(path, uploadId, partEtags);
+            blockingFuture.complete();
+            promise.complete(true);
+      
+      } catch(Exception e) {
+        blockingFuture.fail(e);
+        promise.complete(false);
+      }
+    });
+    return promise.future();
+  }
   private static String buildKey(String tenantId, String fileName) {
     return String.format(
       "%s/%d-%s",

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -120,7 +120,7 @@ public class MinioStorageServiceImpl implements MinioStorageService {
             promise.complete(true);
       
       } catch(Exception e) {
-        e.printStackTrace();
+       
         LOGGER.error("Failed to complete multipart upload {}", e.getMessage());
         blockingFuture.fail(e);
         promise.complete(false);

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -120,6 +120,8 @@ public class MinioStorageServiceImpl implements MinioStorageService {
             promise.complete(true);
       
       } catch(Exception e) {
+        e.printStackTrace();
+        LOGGER.error("Failed to complete multipart upload {}", e.getMessage());
         blockingFuture.fail(e);
         promise.complete(false);
       }

--- a/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
+++ b/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
@@ -84,7 +84,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
     
   }
   @Test
-  public void shouldFailAssembleFileTooSmall(TestContext context) { 
+  public void shouldFailAssembleFileFailedPartUpload(TestContext context) { 
     
     JsonPath info1 =  RestAssured.given()
         .spec(spec)

--- a/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
+++ b/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
@@ -93,11 +93,11 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
       HttpURLConnection con2 = (HttpURLConnection) urlobj2.openConnection();
       con2.setRequestMethod("PUT");
       con2.setDoOutput(true);
-      FileOutputStream output = (FileOutputStream) con2.getOutputStream();
+      OutputStream output =  con2.getOutputStream();
 
       // open file for output
       FileInputStream file = new FileInputStream(
-          new File("/src/test/resources/CornellFOLIOExemplars_Bibs.mrc"));
+          new File("src/test/resources/CornellFOLIOExemplars_Bibs.mrc"));
       output.write(file.readAllBytes());
       tags.add(con2.getHeaderField("eTag"));
     } catch (Exception e) {

--- a/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
+++ b/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
@@ -66,7 +66,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
       output.write(file.readAllBytes());
       tags.add(con.getHeaderField("eTag"));
     } catch (Exception e) {
-      e.printStackTrace();
+      context.fail(e.getMessage());
     }
 
     
@@ -86,7 +86,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
     .statusCode(HttpStatus.SC_OK).log().all()
     .extract().body().jsonPath();
 
-    String url2 = info1.get("url");
+    String url2 = info2.get("url");
  
     try {
       URL urlobj2 = new URL(url2);
@@ -101,7 +101,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
       output.write(file.readAllBytes());
       tags.add(con2.getHeaderField("eTag"));
     } catch (Exception e) {
-
+      context.fail(e.getMessage());
     }
 
     AssembleFileDto dto =  new AssembleFileDto();

--- a/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
+++ b/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
@@ -39,7 +39,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
   @Test
   public void shouldAssembleFileCorrectly(TestContext context) {
     //start upload
-    Async async = context.async();
+  
     JsonPath info1 =  RestAssured.given()
         .spec(spec)
         .when()
@@ -48,8 +48,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
     String uploadId1 = info1.get("uploadId");
     String key1 = info1.get("key");
     
-    async.complete();
-    async = context.async();
+
  
    
     String url1 = info1.get("url");
@@ -66,16 +65,12 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
           new File("src/test/resources/CornellFOLIOExemplars_Bibs.mrc"));
       output.write(file.readAllBytes());
       tags.add(con.getHeaderField("eTag"));
-      for(String i : con.getHeaderFields().keySet()) {
-        System.out.println(i + " " + con.getHeaderField(i));
-      }
     } catch (Exception e) {
       e.printStackTrace();
     }
 
     
-    async.complete();
-    async = context.async();
+
    
 
     //upload 2nd piece
@@ -90,8 +85,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
     .then()
     .statusCode(HttpStatus.SC_OK).log().all()
     .extract().body().jsonPath();
-    async.complete();
-    
+
     String url2 = info1.get("url");
  
     try {
@@ -109,7 +103,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
     } catch (Exception e) {
 
     }
-    
+
     AssembleFileDto dto =  new AssembleFileDto();
     dto.setUploadId(uploadId1);
     dto.setKey(key1);
@@ -122,5 +116,6 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
       .then()
       .log().all()
       .statusCode(HttpStatus.SC_NO_CONTENT);
+    
   }
 }

--- a/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
+++ b/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
@@ -34,8 +35,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
 
   private static final String ASSEMBLE_PATH = "/data-import/assembleStorageFile";
   private static final String UPLOAD_URL_PATH = "/data-import/uploadUrl";
-  private static final String UPLOAD_URL_CONTINUE_PATH =
-      "/data-import/uploadUrl/subsequent";
+  private static final String UPLOAD_URL_CONTINUE_PATH = "/data-import/uploadUrl/subsequent";
   @Test
   public void shouldAssembleFileCorrectly(TestContext context) {
     //start upload
@@ -44,11 +44,7 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
         .spec(spec)
         .when()
         .queryParam("fileName", "test-name1")
-        .post(UPLOAD_URL_PATH )
-        .then()
-        .statusCode(HttpStatus.SC_OK)
-        .log().all()
-        .extract().body().jsonPath();
+        .get(UPLOAD_URL_PATH ).jsonPath();
     String uploadId1 = info1.get("uploadId");
     String key1 = info1.get("key");
     
@@ -61,16 +57,20 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
     try {
       URL urlobj = new URL(url1);
       HttpURLConnection con = (HttpURLConnection) urlobj.openConnection();
-      con.setRequestMethod("POST");
-      FileOutputStream output = (FileOutputStream) con.getOutputStream();
+      con.setRequestMethod("PUT");
+      con.setDoOutput(true);
+      OutputStream output = con.getOutputStream();
 
       // open file for output
       FileInputStream file = new FileInputStream(
-          new File("src/test/resources/mod-data-import/src/test/resources/CornellFOLIOExemplars_Bibs.mrc"));
+          new File("src/test/resources/CornellFOLIOExemplars_Bibs.mrc"));
       output.write(file.readAllBytes());
       tags.add(con.getHeaderField("eTag"));
+      for(String i : con.getHeaderFields().keySet()) {
+        System.out.println(i + " " + con.getHeaderField(i));
+      }
     } catch (Exception e) {
-
+      e.printStackTrace();
     }
 
     
@@ -97,12 +97,13 @@ public class DataImportAssembleFileTest extends AbstractRestTest {
     try {
       URL urlobj2 = new URL(url2);
       HttpURLConnection con2 = (HttpURLConnection) urlobj2.openConnection();
-      con2.setRequestMethod("POST");
+      con2.setRequestMethod("PUT");
+      con2.setDoOutput(true);
       FileOutputStream output = (FileOutputStream) con2.getOutputStream();
 
       // open file for output
       FileInputStream file = new FileInputStream(
-          new File("src/test/resources/mod-data-import/src/test/resources/CornellFOLIOExemplars_Bibs.mrc"));
+          new File("/src/test/resources/CornellFOLIOExemplars_Bibs.mrc"));
       output.write(file.readAllBytes());
       tags.add(con2.getHeaderField("eTag"));
     } catch (Exception e) {

--- a/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
+++ b/src/test/java/org/folio/rest/DataImportAssembleFileTest.java
@@ -1,0 +1,70 @@
+package org.folio.rest;
+
+
+import java.util.ArrayList;
+
+import org.apache.http.HttpStatus;
+
+import org.folio.rest.jaxrs.model.AssembleFileDto;
+import org.folio.rest.jaxrs.model.FileUploadInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+
+import io.restassured.RestAssured;
+import io.restassured.mapper.ObjectMapperType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.path.json.mapper.factory.JsonbObjectMapperFactory;
+import io.restassured.response.Response;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class DataImportAssembleFileTest extends AbstractRestTest {
+
+  private static final String ASSEMBLE_PATH = "/data-import/assembleStorageFile";
+  private static final String UPLOAD_URL_PATH = "/data-import/uploadUrl";
+  private static final String UPLOAD_URL_CONTINUE_PATH =
+      "/data-import/uploadUrl/subsequent";
+  @Test
+  public void shouldAssembleFileCorrectly(TestContext context) {
+    //start upload
+    Async async = context.async();
+    JsonPath info1 =  RestAssured.given()
+        .spec(spec)
+        .when()
+        .queryParam("fileName", "test-name1")
+        .post(UPLOAD_URL_PATH )
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .log().all()
+        .extract().body().jsonPath();
+    String uploadId1 = info1.get("uploadId");
+    String key1 = info1.get("key");
+    
+    async.complete();
+    async = context.async();
+    //upload 1st piece
+   
+    //upload second piece
+  
+  
+    
+  
+    ArrayList<String> tags = new ArrayList<String>();
+
+    AssembleFileDto dto =  new AssembleFileDto();
+    dto.setUploadId("aosidfpvxcohujasleih");
+    dto.setKey("this/is/a/key");
+    dto.setTags(tags);
+    RestAssured.given()
+      .spec(spec)
+      .body(dto, ObjectMapperType.GSON)
+      .when()
+      .post(ASSEMBLE_PATH )
+      .then()
+      .log().all()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
+  }
+}

--- a/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
+++ b/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
@@ -258,8 +258,5 @@ public class MinioStorageServiceTest {
   
     });
   }
-  @Test
-  public void testAssembleFailure(TestContext context) {
-    
-  }
+
 }

--- a/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
+++ b/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
@@ -5,14 +5,23 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+
 import org.folio.rest.jaxrs.model.FileUploadInfo;
+import org.folio.rest.persist.helpers.LocalRowSet;
 import org.folio.s3.client.FolioS3Client;
 import org.folio.s3.exception.S3ClientException;
 import org.junit.Before;
@@ -21,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
 
 @RunWith(VertxUnitRunner.class)
 public class MinioStorageServiceTest {
@@ -212,5 +222,44 @@ public class MinioStorageServiceTest {
       assertEquals("Key did not change", "test-key", fileInfo.getKey());
       async.complete();
     });
+  }
+  @Test
+  public void testAssembleSuccessful(TestContext context) {
+    Async async = context.async();
+    List<String> tags = List.of("etag1","etag2","etag3");
+    
+    doAnswer((InvocationOnMock invocation) -> {
+
+      return null;
+    }).when(
+        folioS3Client
+        ).completeMultipartUpload(
+          "test-key",
+          "upload-id",
+          tags);
+
+
+    
+    Future<Boolean> result = minioStorageService.completeMultipartFileUpload(
+        "test-key",
+        "upload-id",
+        tags);
+    result.onFailure(_err -> {
+      context.fail("completeMultipartFileUpload should not fail");
+    
+    });
+  result.onSuccess(assembleResult -> {
+    Mockito
+    .verify(folioS3Client, times(1))
+    .completeMultipartUpload("test-key", "upload-id", tags);
+  Mockito.verifyNoMoreInteractions(folioS3Client);
+  async.complete();
+
+  
+    });
+  }
+  @Test
+  public void testAssembleFailure(TestContext context) {
+    
   }
 }


### PR DESCRIPTION
## Purpose
Create an API that allows UI to complete an S3 upload.  This api takes in a list of tags created during upload, the file id created by a previous api and the file name called a key.

## Approach
It uses the Folio S3 client functionality built earlier to complete an upload.

#### TODOS and Open Questions
None other then further unit test possibly needed.

## Learning
eTags are retrieved by the UI as a consequence of uploading file parts to the presigned urls provided.  upload ID is not related to folio ids
