### PR TITLE
[MODDATAIMP-892] Allow zero reference values for excluded metrics

### DIFF
--- a/src/main/java/org/folio/service/processing/ranking/ScoreUtils.java
+++ b/src/main/java/org/folio/service/processing/ranking/ScoreUtils.java
@@ -40,6 +40,13 @@ public class ScoreUtils {
     int upperScore,
     @Min(0) int upperReference
   ) {
+    // if the score or value range is 0, we don't care about this metric, so just return zero.
+    // this also prevents a divide-by-zero error later when doing log(upperReference)
+    //   in the event that upperReference == 0
+    if (lowerScore == upperScore || upperReference == 0) {
+      return 0;
+    }
+
     // we must add 1 to the value to avoid taking the log of 0
     double upperLog = Math.log(upperReference + 1.0);
     double valueLog = Math.log(value + 1.0);

--- a/src/test/java/org/folio/service/processing/ranking/ScoreUtilsUnboundedExclusionTest.java
+++ b/src/test/java/org/folio/service/processing/ranking/ScoreUtilsUnboundedExclusionTest.java
@@ -1,0 +1,29 @@
+package org.folio.service.processing.ranking;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+
+public class ScoreUtilsUnboundedExclusionTest {
+
+  @Test
+  public void testExcludedMetrics() {
+    assertThat(
+      ScoreUtils.calculateUnboundedLogarithmicScore(0, 0, 0, 0),
+      is(0d)
+    );
+    assertThat(
+      ScoreUtils.calculateUnboundedLogarithmicScore(10, 0, 0, 0),
+      is(0d)
+    );
+    assertThat(
+      ScoreUtils.calculateUnboundedLogarithmicScore(10, 0, 10, 0),
+      is(0d)
+    );
+    assertThat(
+      ScoreUtils.calculateUnboundedLogarithmicScore(10, 0, 0, 10),
+      is(0d)
+    );
+  }
+}


### PR DESCRIPTION
# [Jira MODDATAIMP-892](https://issues.folio.org/browse/MODDATAIMP-892)
## Purpose
Allow reference values of `0` to be used to exclude a metric entirely. 

## Approach
Add checks before calculating scores to return `0` in these cases, rather than attempting a potentially invalid calclation (divide by zero).

#### TODOS and Open Questions
- [x] Update [the wiki page](https://wiki.folio.org/display/FOLIOtips/Queue+and+chunk+processing+customization)