### PR TITLE
[MODDATAIMP-894] Remove unused DI queue column `size`

### DIFF
--- a/src/main/java/org/folio/dao/DataImportQueueItemDao.java
+++ b/src/main/java/org/folio/dao/DataImportQueueItemDao.java
@@ -58,7 +58,7 @@ public interface DataImportQueueItemDao {
    * Saves {@link DataImportQueueItem} to database
    *
    * @param DataImportQueueItem DataImportQueueItem to save
-   * @return future
+   * @return future with added row's ID
    */
   Future<String> addQueueItem(DataImportQueueItem dataImportQueueItem);
 

--- a/src/main/java/org/folio/dao/DataImportQueueItemDaoImpl.java
+++ b/src/main/java/org/folio/dao/DataImportQueueItemDaoImpl.java
@@ -35,9 +35,9 @@ public class DataImportQueueItemDaoImpl implements DataImportQueueItemDao {
   private static final String GET_BY_ID_SQL =
     "SELECT * FROM %s.%s WHERE id = $1";
   private static final String INSERT_SQL =
-    "INSERT INTO %s.%s (id, jobExecutionId, uploadDefinitionId, tenant, size, originalSize, filePath, timestamp, partNumber, processing) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+    "INSERT INTO %s.%s (id, jobExecutionId, uploadDefinitionId, tenant, originalSize, filePath, timestamp, partNumber, processing) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)";
   private static final String UPDATE_BY_ID_SQL =
-    "UPDATE %s.%s SET jobExecutionId = $2,uploadDefinitionId = $3, tenant = $4,size = $5,originalSize = $6,filePath = $7,timestamp = $8, partNumber = $9, processing = $10 WHERE id = $1";
+    "UPDATE %s.%s SET jobExecutionId = $2, uploadDefinitionId = $3, tenant = $4, originalSize = $5, filePath = $6, timestamp = $7, partNumber = $8, processing = $9 WHERE id = $1";
   private static final String DELETE_BY_ID_SQL =
     "DELETE FROM %s.%s WHERE id = $1";
   private static final String LOCK_ACCESS_EXCLUSIVE_SQL =
@@ -202,7 +202,6 @@ public class DataImportQueueItemDaoImpl implements DataImportQueueItemDao {
           dataImportQueueItem.getJobExecutionId(),
           dataImportQueueItem.getTenant(),
           dataImportQueueItem.getUploadDefinitionId(),
-          dataImportQueueItem.getSize(),
           dataImportQueueItem.getOriginalSize(),
           dataImportQueueItem.getFilePath(),
           dataImportQueueItem.getTimestamp(),
@@ -234,7 +233,6 @@ public class DataImportQueueItemDaoImpl implements DataImportQueueItemDao {
             dataImportQueueItem.getJobExecutionId(),
             dataImportQueueItem.getUploadDefinitionId(),
             dataImportQueueItem.getTenant(),
-            dataImportQueueItem.getSize(),
             dataImportQueueItem.getOriginalSize(),
             dataImportQueueItem.getFilePath(),
             dataImportQueueItem.getTimestamp(),
@@ -294,7 +292,6 @@ public class DataImportQueueItemDaoImpl implements DataImportQueueItemDao {
     queueItem.setUploadDefinitionId(rowAsJson.getString("uploadDefinitionId"));
     queueItem.setTenant(rowAsJson.getString("tenant"));
     queueItem.setFilePath(rowAsJson.getString("filePath"));
-    queueItem.setSize(rowAsJson.getInteger("size"));
     queueItem.setOriginalSize(rowAsJson.getInteger("originalSize"));
     queueItem.setTimestamp(rowAsJson.getString("timeStamp"));
     queueItem.setPartNumber(rowAsJson.getInteger("partNumber"));

--- a/src/main/resources/liquibase/module/scripts/v-0.0.1/2023-08-14--00-00-remove-queue-item-size-column.xml
+++ b/src/main/resources/liquibase/module/scripts/v-0.0.1/2023-08-14--00-00-remove-queue-item-size-column.xml
@@ -1,0 +1,8 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+  <changeSet id="2023-08-14--00-00-remove-queue-item-size-column" author="ncovercash">
+    <dropColumn tableName="dataImportQueueItems" columnName="size" />
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/folio/dao/DataImportQueueDaoTest.java
+++ b/src/test/java/org/folio/dao/DataImportQueueDaoTest.java
@@ -122,7 +122,6 @@ public class DataImportQueueDaoTest {
     queueItem.setId(storedItemUUID.toString());
     queueItem.setUploadDefinitionId(UUID.randomUUID().toString());
     queueItem.setJobExecutionId(UUID.randomUUID().toString());
-    queueItem.setSize(1000);
     queueItem.setOriginalSize(5000);
     DateTime now = new DateTime();
     queueItem.setTimestamp(now.toString());
@@ -347,7 +346,6 @@ public class DataImportQueueDaoTest {
     queueItem.setId(storedItemUUID.toString());
     queueItem.setUploadDefinitionId(UUID.randomUUID().toString());
     queueItem.setJobExecutionId(UUID.randomUUID().toString());
-    queueItem.setSize(1000);
     queueItem.setOriginalSize(5000);
     DateTime now = new DateTime();
     queueItem.setTimestamp(now.toString());


### PR DESCRIPTION
# [Jira MODDATAIMP-894](https://issues.folio.org/browse/MODDATAIMP-894)

## Purpose

We opted not to consider chunk size as a metric for prioritizing queue items; therefore, this column is no longer needed.

## Approach
This removes the support from the DAO and provides a Liquibase changelog to drop the column in the database.