### PR TITLE
[MODDATAIMP-873] Change file extension validation messages which are represented in code format

### DIFF
--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -45,8 +45,8 @@ public class DataImportImpl implements DataImport {
 
   private static final Logger LOGGER = LogManager.getLogger();
 
-  private static final String FILE_EXTENSION_DUPLICATE_ERROR_CODE = "fileExtension.duplication.invalid";
-  private static final String FILE_EXTENSION_INVALID_ERROR_CODE = "fileExtension.extension.invalid";
+  private static final String FILE_EXTENSION_DUPLICATE_ERROR_MESSAGE = "File extension %s already exists";
+  private static final String FILE_EXTENSION_INVALID_ERROR_MESSAGE = "File extension %s is not a valid format";
   private static final String FILE_EXTENSION_VALIDATE_ERROR_MESSAGE = "Failed to validate file extension";
   private static final String UPLOAD_DEFINITION_VALIDATE_ERROR_MESSAGE = "Failed to validate Upload Definition";
   private static final String FILE_EXTENSION_VALID_REGEXP = "^\\.(\\w+)$";
@@ -436,11 +436,11 @@ public class DataImportImpl implements DataImport {
       .withTotalRecords(0);
     return Future.succeededFuture()
       .map(v -> !extension.getExtension().matches(FILE_EXTENSION_VALID_REGEXP)
-        ? errors.withErrors(Collections.singletonList(new Error().withMessage(FILE_EXTENSION_INVALID_ERROR_CODE))).withTotalRecords(errors.getErrors().size() + 1)
+        ? errors.withErrors(Collections.singletonList(new Error().withMessage(String.format(FILE_EXTENSION_INVALID_ERROR_MESSAGE, extension.getExtension())))).withTotalRecords(errors.getErrors().size() + 1)
         : errors)
       .compose(errorsReply -> fileExtensionService.isFileExtensionExistByName(extension, tenantId))
       .map(exist -> exist && errors.getTotalRecords() == 0
-        ? errors.withErrors(Collections.singletonList(new Error().withMessage(FILE_EXTENSION_DUPLICATE_ERROR_CODE))).withTotalRecords(errors.getErrors().size() + 1)
+        ? errors.withErrors(Collections.singletonList(new Error().withMessage(String.format(FILE_EXTENSION_DUPLICATE_ERROR_MESSAGE, extension.getExtension())))).withTotalRecords(errors.getErrors().size() + 1)
         : errors);
   }
 

--- a/src/test/java/org/folio/rest/FileExtensionAPITest.java
+++ b/src/test/java/org/folio/rest/FileExtensionAPITest.java
@@ -331,7 +331,7 @@ public class FileExtensionAPITest extends AbstractRestTest {
       .then()
       .log().all()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-      .body("errors[0].message", is("fileExtension.duplication.invalid"));
+      .body("errors[0].message", is("File extension .varc already exists"));
   }
 
   @Test
@@ -354,7 +354,7 @@ public class FileExtensionAPITest extends AbstractRestTest {
       .post(FILE_EXTENSION_PATH)
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-      .body("errors[0].message", is("fileExtension.duplication.invalid"));
+      .body("errors[0].message", is("File extension .marc already exists"));
 
     RestAssured.given()
       .spec(spec)
@@ -363,7 +363,7 @@ public class FileExtensionAPITest extends AbstractRestTest {
       .post(FILE_EXTENSION_PATH)
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-      .body("errors[0].message", is("fileExtension.extension.invalid"));
+      .body("errors[0].message", is("File extension  .marc  is not a valid format"));
   }
 
   @Test
@@ -390,7 +390,7 @@ public class FileExtensionAPITest extends AbstractRestTest {
       .post(FILE_EXTENSION_PATH)
       .then().log().all()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-      .body("errors[0].message", is("fileExtension.extension.invalid"));
+      .body("errors[0].message", is("File extension ma rc is not a valid format"));
   }
 
 }


### PR DESCRIPTION
## Purpose
Resolves: [MODDATAIMP-873](https://issues.folio.org/browse/MODDATAIMP-873) Change file extension validation messages which are represented in code format

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
