### PR TITLE
[MODDATAIMP-910] Update cancellation endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -155,6 +155,7 @@
           ],
           "modulePermissions": [
             "change-manager.jobexecutions.get",
+            "change-manager.jobexecutions.post",
             "change-manager.jobexecutions.put",
             "mapping-metadata.get",
             "source-storage.records.get",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -30,15 +30,6 @@
       "handlers": [
       	{
           "methods": [
-            "DELETE"
-          ],
-          "pathPattern": "/data-import/jobexecutions/{jobExecutionId}/cancel",
-          "permissionsRequired": [
-            "data-import.jobexecution.cancel"
-          ]
-        },
-      	{
-          "methods": [
             "GET"
           ],
           "pathPattern": "/data-import/splitStatus",
@@ -324,6 +315,11 @@
           "methods": ["GET"],
           "pathPattern": "/data-import/jobExecutions/{id}/downloadUrl",
           "permissionsRequired": ["data-import.downloadUrl.get"]
+        },
+      	{
+          "methods": ["DELETE"],
+          "pathPattern": "/data-import/jobExecutions/{jobExecutionId}/cancel",
+          "permissionsRequired": ["data-import.jobexecution.cancel"]
         },
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -320,7 +320,8 @@
       	{
           "methods": ["DELETE"],
           "pathPattern": "/data-import/jobExecutions/{jobExecutionId}/cancel",
-          "permissionsRequired": ["data-import.jobexecution.cancel"]
+          "permissionsRequired": ["data-import.jobexecution.cancel"],
+          "modulePermissions": ["change-manager.jobexecutions.put"]
         },
         {
           "methods": ["GET"],

--- a/ramls/dataImport.raml
+++ b/ramls/dataImport.raml
@@ -35,6 +35,7 @@ types:
   fileDownloadInfo: !include raml-storage/schemas/mod-data-import/fileDownloadInfo.json
   splitStatus: !include raml-storage/schemas/dto/splitStatus.json
   assembleFileDto: !include raml-storage/schemas/dto/assembleFileDto.json
+  cancelResponse: !include raml-storage/schemas/mod-data-import/cancelResponse.json
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml
   language: !include raml-storage/raml-util/traits/language.raml
@@ -205,7 +206,7 @@ resourceTypes:
           200:
             body:
               application/json:
-                type: string
+                type: cancelResponse
           500:
             body:
               application/json:

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -20,7 +20,6 @@ import org.folio.rest.annotations.Stream;
 import org.folio.rest.client.ChangeManagerClient;
 import org.folio.rest.jaxrs.model.AssembleFileDto;
 import org.folio.rest.jaxrs.model.CancelResponse;
-import org.folio.rest.jaxrs.model.DataImportJobExecutionsJobExecutionIdCancelDelete200ApplicationJson;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.FileDefinition;

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -19,6 +19,8 @@ import org.folio.rest.RestVerticle;
 import org.folio.rest.annotations.Stream;
 import org.folio.rest.client.ChangeManagerClient;
 import org.folio.rest.jaxrs.model.AssembleFileDto;
+import org.folio.rest.jaxrs.model.CancelResponse;
+import org.folio.rest.jaxrs.model.DataImportJobExecutionsJobExecutionIdCancelDelete200ApplicationJson;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.FileDefinition;
@@ -559,7 +561,9 @@ public class DataImportImpl implements DataImport {
 
     vertxContext.runOnContext(v ->
       splitFileProcessingService.cancelJob(jobExecutionId, params, client)
-        .map(vv -> DeleteDataImportJobExecutionsCancelByJobExecutionIdResponse.respond200WithApplicationJson("Job successfully cancelled"))
+        .map(vv -> DeleteDataImportJobExecutionsCancelByJobExecutionIdResponse.respond200WithApplicationJson(
+          new CancelResponse().withOk(true)
+        ))
         .map(Response.class::cast)
         .onComplete(asyncResultHandler)
     );

--- a/src/main/java/org/folio/service/file/SplitFileProcessingService.java
+++ b/src/main/java/org/folio/service/file/SplitFileProcessingService.java
@@ -352,7 +352,7 @@ public class SplitFileProcessingService {
       .compose((JobExecution jobExecution) -> {
         if (
           jobExecution.getSubordinationType() ==
-          JobExecution.SubordinationType.PARENT_MULTIPLE
+          JobExecution.SubordinationType.COMPOSITE_PARENT
         ) {
           return client.getChangeManagerJobExecutionsChildrenById(
             jobExecutionId,
@@ -373,16 +373,29 @@ public class SplitFileProcessingService {
       )
       // we have the list of children
       .compose((JobExecutionDtoCollection collection) -> {
-        List<Future<Void>> deleteQueueFutures = new ArrayList<>();
+        List<Future<Void>> futures = new ArrayList<>();
+
+        // parent execution
+        futures.add(
+          client
+            .putChangeManagerJobExecutionsStatusById(
+              jobExecutionId,
+              new StatusDto().withStatus(StatusDto.Status.CANCELLED)
+            )
+            .map(this::verifyOkStatus)
+            .mapEmpty()
+        );
+
+        // all children
         for (JobExecutionDto exec : collection.getJobExecutions()) {
-          deleteQueueFutures.add(
+          futures.add(
             queueItemDao
               .deleteDataImportQueueItemByJobExecutionId(exec.getId())
               // the delete call can fail if the queue item doesn't exist (has already been processed)
               .recover(err -> Future.succeededFuture())
           );
 
-          deleteQueueFutures.add(
+          futures.add(
             client
               .putChangeManagerJobExecutionsStatusById(
                 exec.getId(),
@@ -394,12 +407,10 @@ public class SplitFileProcessingService {
         }
 
         return CompositeFuture.all(
-          deleteQueueFutures
-            .stream()
-            .map(Future.class::cast)
-            .collect(Collectors.toList())
+          futures.stream().map(Future.class::cast).collect(Collectors.toList())
         );
       })
+      .onFailure(err -> LOGGER.error("Error cancelling job", err))
       .mapEmpty();
   }
 

--- a/src/test/java/org/folio/rest/CancelJobExecutionTest.java
+++ b/src/test/java/org/folio/rest/CancelJobExecutionTest.java
@@ -188,7 +188,7 @@ public class CancelJobExecutionTest extends AbstractRestTest {
             )
           );
           verify(
-            exactly(4),
+            exactly(5),
             putRequestedFor(
               urlPathMatching("/change-manager/jobExecutions/.*/status")
             )

--- a/src/test/java/org/folio/rest/CancelJobExecutionTest.java
+++ b/src/test/java/org/folio/rest/CancelJobExecutionTest.java
@@ -19,7 +19,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.folio.dao.DataImportQueueItemDao;
@@ -68,33 +67,61 @@ public class CancelJobExecutionTest extends AbstractRestTest {
   @Test
   public void testSuccess(TestContext context) {
     String parentId = "fb1036b0-dd35-4b61-8b64-b041530ba23c";
-    String childId1 = "fcdada31-4804-4a61-82c7-0ecb45f91bb2";
-    String childId2 = "794a291f-2977-4b9b-a9eb-b03565645440";
-    String childId3 = "7bbc916a-d486-4daf-bc6b-6c72648e0b01";
-    String childId4 = "a6f70f51-cf03-4879-a926-dab07a7eebf5";
 
-    // set up a few child job executions with parent
-    JobExecution childJob1 = new JobExecution()
-      .withId(childId1)
-      .withParentJobId(parentId);
-    JobExecution childJob2 = new JobExecution()
-      .withId(childId2)
-      .withParentJobId(parentId);
-    JobExecution childJob3 = new JobExecution()
-      .withId(childId3)
-      .withParentJobId(parentId);
-    JobExecution childJob4 = new JobExecution()
-      .withId(childId4)
-      .withParentJobId(parentId);
+    // test different states
+    String newId = "2a1279bb-cbac-5940-8f4d-e49ff41b3fd3";
+    String parsingInProgressId = "13d3a5fa-efe6-5319-80e1-eb43dc2b8fb5";
+    String parsingFinishedId = "d89fb7a5-6c9b-5bde-b76a-f4871ab4a541";
+    String processingInProgressId = "bdb500bb-abb4-5c15-bbf7-9c995f532cbd";
+    String processingFinishedId = "199f2e6c-06f4-5331-ad06-b4d0163b211d";
+    String commitInProgressId = "d7e14feb-3065-590e-b1dc-90985098c7a1";
+    String committedId = "c470797a-6a49-5e63-bc2c-cd2562e3c065";
+    String errorId = "f1e9782d-2afd-58c9-b152-f659d522a45c";
+    String discardedId = "aebc9987-c533-55db-8649-5999f36fc43c";
+    String cancelledId = "3b42b27c-e624-5f53-bbb5-13c079c266c7";
 
-    List<JobExecutionDto> childList = Arrays.asList(
-      new JobExecutionDto().withId(childJob1.getId()),
-      new JobExecutionDto().withId(childJob2.getId()),
-      new JobExecutionDto().withId(childJob3.getId()),
-      new JobExecutionDto().withId(childJob4.getId())
-    );
+    JobExecutionDto newJob = new JobExecutionDto()
+      .withId(newId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.NEW);
+    JobExecutionDto parsingInProgressJob = new JobExecutionDto()
+      .withId(parsingInProgressId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.PARSING_IN_PROGRESS);
+    JobExecutionDto parsingFinishedJob = new JobExecutionDto()
+      .withId(parsingFinishedId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.PARSING_FINISHED);
+    JobExecutionDto processingInProgressJob = new JobExecutionDto()
+      .withId(processingInProgressId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.PROCESSING_IN_PROGRESS);
+    JobExecutionDto processingFinishedJob = new JobExecutionDto()
+      .withId(processingFinishedId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.PROCESSING_FINISHED);
+    JobExecutionDto commitInProgressJob = new JobExecutionDto()
+      .withId(commitInProgressId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.COMMIT_IN_PROGRESS);
+    JobExecutionDto committedJob = new JobExecutionDto()
+      .withId(committedId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.COMMITTED);
+    JobExecutionDto errorJob = new JobExecutionDto()
+      .withId(errorId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.ERROR);
+    JobExecutionDto discardedJob = new JobExecutionDto()
+      .withId(discardedId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.DISCARDED);
+    JobExecutionDto cancelledJob = new JobExecutionDto()
+      .withId(cancelledId)
+      .withParentJobId(parentId)
+      .withStatus(JobExecutionDto.Status.CANCELLED);
 
-    // set up job execution
+    // set up parent job execution
     JobExecution cancelJob = new JobExecution()
       .withId(parentId)
       .withSubordinationType(JobExecution.SubordinationType.COMPOSITE_PARENT);
@@ -116,40 +143,57 @@ public class CancelJobExecutionTest extends AbstractRestTest {
           okJson(
             JsonObject
               .mapFrom(
-                new JobExecutionDtoCollection().withJobExecutions(childList)
+                new JobExecutionDtoCollection()
+                  .withJobExecutions(
+                    Arrays.asList(
+                      newJob,
+                      parsingInProgressJob,
+                      parsingFinishedJob,
+                      processingInProgressJob,
+                      processingFinishedJob,
+                      commitInProgressJob,
+                      committedJob,
+                      errorJob,
+                      discardedJob,
+                      cancelledJob
+                    )
+                  )
               )
               .encode()
           )
         )
     );
 
+    // entirely arbitrary which ones we choose here; just want to have some to reference
+    // when cancelling child jobs, it will delete from the queue if present, but it does not
+    // use that as an indicator of if it's processed/etc.
     CompositeFuture
       .all(
         queueItemDao.addQueueItem(
           new DataImportQueueItem()
             .withId("9eb41611-dad4-45ee-9632-07d0dc2033dd")
-            .withJobExecutionId(childId1)
+            .withJobExecutionId(newJob.getId())
             .withUploadDefinitionId("0bbcd4bd-33b7-4ced-9806-b83f0072797f")
             .withTimestamp(new Date())
         ),
         queueItemDao.addQueueItem(
           new DataImportQueueItem()
             .withId("aa3480d4-f842-4425-a195-a93423803d2b")
-            .withJobExecutionId(childId2)
+            .withJobExecutionId(parsingInProgressJob.getId())
             .withUploadDefinitionId("65bf117b-98ea-44e8-b5a2-c0f925e7989c")
             .withTimestamp(new Date())
         ),
         queueItemDao.addQueueItem(
           new DataImportQueueItem()
             .withId("f29efbb0-d9f7-4f99-a84e-d8901ef4eb0e")
-            .withJobExecutionId(childId3)
+            .withJobExecutionId(parsingFinishedJob.getId())
             .withUploadDefinitionId("eb184d75-188a-4f5b-9f3f-d4735d7748d1")
             .withTimestamp(new Date())
         ),
         queueItemDao.addQueueItem(
           new DataImportQueueItem()
             .withId("b7bdf243-4ff7-430a-85f2-72c3215f1859")
-            .withJobExecutionId(childId4)
+            .withJobExecutionId(processingInProgressJob.getId())
             .withUploadDefinitionId("62004e64-865c-41c8-8524-a7ddaa367430")
             .withTimestamp(new Date())
         )
@@ -187,8 +231,32 @@ public class CancelJobExecutionTest extends AbstractRestTest {
               urlPathMatching("/change-manager/jobExecutions/.*/children")
             )
           );
+
+          // verify all the actual cancels
+          Arrays
+            .asList(
+              parentId,
+              newId,
+              parsingInProgressId,
+              parsingFinishedId,
+              processingInProgressId,
+              processingFinishedId,
+              commitInProgressId
+            )
+            .forEach(id -> {
+              verify(
+                exactly(1),
+                putRequestedFor(
+                  urlPathMatching(
+                    "/change-manager/jobExecutions/" + id + "/status"
+                  )
+                )
+              );
+            });
+
+          // verify no more than those verified above
           verify(
-            exactly(5),
+            exactly(7),
             putRequestedFor(
               urlPathMatching("/change-manager/jobExecutions/.*/status")
             )

--- a/src/test/java/org/folio/rest/CancelJobExecutionTest.java
+++ b/src/test/java/org/folio/rest/CancelJobExecutionTest.java
@@ -73,7 +73,7 @@ public class CancelJobExecutionTest extends AbstractRestTest {
     String childId3 = "7bbc916a-d486-4daf-bc6b-6c72648e0b01";
     String childId4 = "a6f70f51-cf03-4879-a926-dab07a7eebf5";
 
-    //set up a few child job executions with parent
+    // set up a few child job executions with parent
     JobExecution childJob1 = new JobExecution()
       .withId(childId1)
       .withParentJobId(parentId);
@@ -94,18 +94,18 @@ public class CancelJobExecutionTest extends AbstractRestTest {
       new JobExecutionDto().withId(childJob4.getId())
     );
 
-    //set up job execution
+    // set up job execution
     JobExecution cancelJob = new JobExecution()
       .withId(parentId)
-      .withSubordinationType(JobExecution.SubordinationType.PARENT_MULTIPLE);
+      .withSubordinationType(JobExecution.SubordinationType.COMPOSITE_PARENT);
 
-    //mock response to parent
+    // mock response to parent
     WireMock.stubFor(
       get(urlPathMatching("/change-manager/jobExecutions/" + parentId))
         .willReturn(okJson(JsonObject.mapFrom(cancelJob).encode()))
     );
 
-    //mock response to children
+    // mock response to children
     WireMock.stubFor(
       get(
         urlPathMatching(
@@ -156,7 +156,7 @@ public class CancelJobExecutionTest extends AbstractRestTest {
       )
       .onComplete(
         context.asyncAssertSuccess(result -> {
-          //make request to cancel parent
+          // make request to cancel parent
           RestAssured
             .given()
             .spec(spec)
@@ -201,18 +201,18 @@ public class CancelJobExecutionTest extends AbstractRestTest {
   public void testNonParent(TestContext context) {
     String parentId = "fb1036b0-dd35-4b61-8b64-b041530ba23c";
 
-    //set up job execution
+    // set up job execution
     JobExecution job = new JobExecution()
       .withId(parentId)
-      .withSubordinationType(JobExecution.SubordinationType.PARENT_SINGLE);
+      .withSubordinationType(JobExecution.SubordinationType.COMPOSITE_CHILD);
 
-    //mock response to parent
+    // mock response to parent
     WireMock.stubFor(
       get(urlPathMatching("/change-manager/jobExecutions/" + parentId))
         .willReturn(okJson(JsonObject.mapFrom(job).encode()))
     );
 
-    //make request to cancel parent
+    // make request to cancel parent
     RestAssured
       .given()
       .spec(spec)
@@ -229,13 +229,13 @@ public class CancelJobExecutionTest extends AbstractRestTest {
   public void testNotFound(TestContext context) {
     String parentId = "fb1036b0-dd35-4b61-8b64-b041530ba23c";
 
-    //mock response to parent
+    // mock response to parent
     WireMock.stubFor(
       get(urlPathMatching("/change-manager/jobExecutions/" + parentId))
         .willReturn(notFound())
     );
 
-    //make request to cancel parent
+    // make request to cancel parent
     RestAssured
       .given()
       .spec(spec)

--- a/src/test/java/org/folio/rest/DataImportCancelJobExecutionTest.java
+++ b/src/test/java/org/folio/rest/DataImportCancelJobExecutionTest.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import io.restassured.RestAssured;
@@ -159,7 +160,8 @@ public class DataImportCancelJobExecutionTest extends AbstractRestTest {
             .then()
             .log()
             .all()
-            .statusCode(HttpStatus.SC_OK);
+            .statusCode(HttpStatus.SC_OK)
+            .body("ok", is(true));
         })
       );
   }


### PR DESCRIPTION
# [Jira MODDATAIMP-910](https://issues.folio.org/browse/MODDATAIMP-910)

## Purpose
Alter the response of the cancel endpoint to be consistent with the previous SRM-based implementation.

This PR also includes a few fixes for the cancellation logic that seems to have been missing/not merged into the main `release` branch (likely due to hotfixes/testing commits on the `test` branch), as well as a fix to ensure we don't accidentally mark completed jobs as cancelled.