### PR TITLE
[MODDATAIMP-911] [Release branch] Add totalRecordsInFile field for JobExecutions

### DIFF
--- a/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
+++ b/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
@@ -38,6 +38,7 @@ import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.rest.jaxrs.model.File;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
+import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionDto;
 import org.folio.rest.jaxrs.model.ProcessFilesRqDto;
 import org.folio.rest.jaxrs.model.StatusDto;
@@ -266,6 +267,18 @@ public class SplitFileProcessingServiceStartJobTest
       })
       .when(changeManagerClient)
       .postChangeManagerJobExecutions(any(), any());
+
+    when(
+      changeManagerClient.putChangeManagerJobExecutionsById(any(), any(), any())
+    )
+      .thenAnswer(invocation -> {
+        assertThat(
+          invocation.<JobExecution>getArgument(2).getTotalRecordsInFile(),
+          is(10)
+        );
+
+        return getSuccessArBuffer(null);
+      });
 
     service
       .initializeJob(


### PR DESCRIPTION
Release version of #287

# [Jira MODDATAIMP-911](https://issues.folio.org/browse/MODDATAIMP-911)

## Purpose
Add a field to job executions to store the total number of records, to prevent thje delay as chunks are processed and "counting" in the UI.

## Approach
This sends the field added to mod-srm in https://github.com/folio-org/mod-source-record-manager/pull/804.  Some minor refactoring was also done to the service.

## Coverage :100:
(all applicable tests were updated)

