### PR TITLE
[MODDATAIMP-914] Prefix S3 files with data-import/

### DIFF
--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -550,14 +550,8 @@ public class DataImportImpl implements DataImport {
         )
         .compose(fileDefinition ->
           minioStorageService.completeMultipartFileUpload(entity.getKey(), entity.getUploadId(), entity.getTags())
-            .map(completed -> Pair.of(fileDefinition, completed))
+            .map(vv -> fileDefinition)
         )
-        .compose(result -> {
-          if (Boolean.FALSE.equals(result.getRight())) {
-            return Future.failedFuture("Failed to assemble Data Import upload file");
-          }
-          return Future.succeededFuture(result.getLeft());
-        })
         .compose(fileDefinition -> fileService.afterFileSave(fileDefinition.withSourcePath(entity.getKey()), params))
         .map(vv -> PostDataImportUploadDefinitionsFilesAssembleStorageFileByUploadDefinitionIdAndFileIdResponse.respond204())
         .map(Response.class::cast)

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -9,7 +9,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.ExceptionHelper;

--- a/src/main/java/org/folio/service/s3storage/MinioStorageService.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageService.java
@@ -70,7 +70,7 @@ public interface MinioStorageService {
    * @param etags the list of etags returned from part uploads
    * @return
    */
-  Future<Boolean> completeMultipartFileUpload(
+  Future<Void> completeMultipartFileUpload(
     String key,
     String uploadId,
     List<String> etags

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -1,6 +1,5 @@
 package org.folio.service.s3storage;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -38,13 +37,13 @@ public class MinioStorageServiceImpl implements MinioStorageService {
     String uploadFileName,
     String tenantId
   ) {
-    Promise<String> uploadIdPromise = Promise.promise();
     FolioS3Client client = folioS3ClientFactory.getFolioS3Client();
 
     String key = buildKey(tenantId, uploadFileName);
 
-    vertx.executeBlocking(
-      (Promise<String> blockingFuture) -> {
+    return vertx
+      .executeBlocking((Promise<String> blockingFuture) -> {
+        // we just built the key; no need to verify
         try {
           String uploadId = client.initiateMultipartUpload(key);
           LOGGER.info("Created upload ID {} for key {}", uploadId, key);
@@ -52,18 +51,7 @@ public class MinioStorageServiceImpl implements MinioStorageService {
         } catch (S3ClientException e) {
           blockingFuture.fail(e);
         }
-      },
-      (AsyncResult<String> asyncResult) -> {
-        if (asyncResult.failed()) {
-          uploadIdPromise.fail(asyncResult.cause());
-        } else {
-          uploadIdPromise.complete(asyncResult.result());
-        }
-      }
-    );
-
-    return uploadIdPromise
-      .future()
+      })
       .compose(outcome -> getFileUploadPartUrl(key, outcome, 1));
   }
 
@@ -73,12 +61,13 @@ public class MinioStorageServiceImpl implements MinioStorageService {
     String uploadId,
     int partNumber
   ) {
-    Promise<FileUploadInfo> promise = Promise.promise();
     FolioS3Client client = folioS3ClientFactory.getFolioS3Client();
 
-    vertx.executeBlocking(
-      (Promise<String> blockingFuture) -> {
+    return vertx
+      .executeBlocking((Promise<String> blockingFuture) -> {
         try {
+          verifyKey(key);
+
           LOGGER.info(
             "Getting presigned URL for part {} of key {}/upload ID {}",
             partNumber,
@@ -91,160 +80,115 @@ public class MinioStorageServiceImpl implements MinioStorageService {
         } catch (S3ClientException e) {
           blockingFuture.fail(e);
         }
-      },
-      (AsyncResult<String> asyncResult) -> {
-        if (asyncResult.failed()) {
-          promise.fail(asyncResult.cause());
-        } else {
-          String url = asyncResult.result();
-          FileUploadInfo fileUpload = new FileUploadInfo();
-          fileUpload.setUrl(url);
-          fileUpload.setKey(key);
-          fileUpload.setUploadId(uploadId);
-          promise.complete(fileUpload);
-        }
-      }
-    );
-
-    return promise.future();
+      })
+      .map(url ->
+        new FileUploadInfo().withUrl(url).withKey(key).withUploadId(uploadId)
+      );
   }
 
   @Override
   public Future<FileDownloadInfo> getFileDownloadUrl(String key) {
-    Promise<FileDownloadInfo> promise = Promise.promise();
     FolioS3Client client = folioS3ClientFactory.getFolioS3Client();
 
-    vertx.executeBlocking(
-      (Promise<String> blockingFuture) -> {
+    return vertx
+      .executeBlocking((Promise<String> blockingFuture) -> {
         try {
+          verifyKey(key);
+
           LOGGER.info("Getting presigned URL for key {}", key);
           blockingFuture.complete(client.getPresignedUrl(key));
         } catch (S3ClientException e) {
           blockingFuture.fail(e);
         }
-      },
-      (AsyncResult<String> asyncResult) -> {
-        if (asyncResult.failed()) {
-          promise.fail(asyncResult.cause());
-        } else {
-          promise.complete(
-            new FileDownloadInfo().withUrl(asyncResult.result())
-          );
-        }
-      }
-    );
-
-    return promise.future();
+      })
+      .map(url -> new FileDownloadInfo().withUrl(url));
   }
 
   @Override
   public Future<InputStream> readFile(String key) {
-    Promise<InputStream> inStreamPromise = Promise.promise();
     FolioS3Client client = folioS3ClientFactory.getFolioS3Client();
 
-    vertx.executeBlocking(
-      (Promise<InputStream> blockingFuture) -> {
-        try {
-          LOGGER.info(
-            "Created input stream to read remote file for key {}",
-            key
-          );
-          InputStream inStream = client.read(key);
-          blockingFuture.complete(inStream);
-        } catch (S3ClientException e) {
-          LOGGER.error("Could not read from S3:", e);
-          blockingFuture.fail(e);
-        }
-      },
-      (AsyncResult<InputStream> asyncResult) -> {
-        if (asyncResult.failed()) {
-          inStreamPromise.fail(asyncResult.cause());
-        } else {
-          inStreamPromise.complete(asyncResult.result());
-        }
+    return vertx.executeBlocking((Promise<InputStream> blockingFuture) -> {
+      try {
+        verifyKey(key);
+
+        LOGGER.info("Created input stream to read remote file for key {}", key);
+        InputStream inStream = client.read(key);
+        blockingFuture.complete(inStream);
+      } catch (S3ClientException e) {
+        LOGGER.error("Could not read from S3:", e);
+        blockingFuture.fail(e);
       }
-    );
-    return inStreamPromise.future();
+    });
   }
 
   @Override
   public Future<String> write(String path, InputStream is) {
-    Promise<String> stringPromise = Promise.promise();
     FolioS3Client client = folioS3ClientFactory.getFolioS3Client();
 
-    vertx.executeBlocking(
-      (Promise<String> blockingFuture) -> {
-        try {
-          LOGGER.info("Writing remote file for path {}", path);
-          String filePath = client.write(path, is);
-          blockingFuture.complete(filePath);
-        } catch (S3ClientException e) {
-          blockingFuture.fail(e);
-        }
-      },
-      (AsyncResult<String> asyncResult) -> {
-        if (asyncResult.failed()) {
-          stringPromise.fail(asyncResult.cause());
-        } else {
-          stringPromise.complete(asyncResult.result());
-        }
+    return vertx.executeBlocking((Promise<String> blockingFuture) -> {
+      try {
+        verifyKey(path);
+
+        LOGGER.info("Writing remote file for path {}", path);
+        String filePath = client.write(path, is);
+        blockingFuture.complete(filePath);
+      } catch (S3ClientException e) {
+        blockingFuture.fail(e);
       }
-    );
-    return stringPromise.future();
+    });
   }
 
   @Override
   public Future<Void> remove(String key) {
-    Promise<Void> promise = Promise.promise();
     FolioS3Client client = folioS3ClientFactory.getFolioS3Client();
 
-    vertx.executeBlocking(
-      (Promise<Void> blockingFuture) -> {
-        try {
-          LOGGER.info("Deleting file {}", key);
-          client.remove(key);
-          blockingFuture.complete();
-        } catch (S3ClientException e) {
-          LOGGER.error("Could not remove from S3:", e);
-          blockingFuture.fail(e);
-        }
-      },
-      (AsyncResult<Void> asyncResult) -> {
-        if (asyncResult.failed()) {
-          promise.fail(asyncResult.cause());
-        } else {
-          promise.complete(asyncResult.result());
-        }
+    return vertx.executeBlocking((Promise<Void> blockingFuture) -> {
+      try {
+        verifyKey(key);
+
+        LOGGER.info("Deleting file {}", key);
+        client.remove(key);
+        blockingFuture.complete();
+      } catch (S3ClientException e) {
+        LOGGER.error("Could not remove from S3:", e);
+        blockingFuture.fail(e);
       }
-    );
-    return promise.future();
+    });
   }
 
-  public Future<Boolean> completeMultipartFileUpload(
+  public Future<Void> completeMultipartFileUpload(
     String path,
     String uploadId,
     List<String> partEtags
   ) {
-    Promise<Boolean> promise = Promise.promise();
     FolioS3Client client = folioS3ClientFactory.getFolioS3Client();
 
-    vertx.executeBlocking((Promise<String> blockingFuture) -> {
+    return vertx.executeBlocking((Promise<Void> blockingFuture) -> {
       try {
+        verifyKey(path);
+
         client.completeMultipartUpload(path, uploadId, partEtags);
+
         blockingFuture.complete();
-        promise.complete(true);
-      } catch (Exception e) {
+      } catch (S3ClientException e) {
         LOGGER.error("Failed to complete multipart upload", e);
         blockingFuture.fail(e);
-        promise.complete(false);
       }
     });
-    return promise.future();
+  }
+
+  private static void verifyKey(String key) {
+    if (!key.startsWith("data-import/")) {
+      throw new IllegalArgumentException(
+        "Key must be located in folder 'data-import/' but was " + key
+      );
+    }
   }
 
   private static String buildKey(String tenantId, String fileName) {
     return String.format(
-      "%s/%d-%s",
+      "data-import/%s/%d-%s",
       tenantId,
       System.currentTimeMillis(),
       fileName

--- a/src/test/java/org/folio/rest/DownloadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/DownloadUrlAPITest.java
@@ -30,7 +30,10 @@ public class DownloadUrlAPITest extends AbstractRestTest {
         .willReturn(
           okJson(
             JsonObject
-              .mapFrom(new JobExecution().withSourcePath("test-key-response"))
+              .mapFrom(
+                new JobExecution()
+                  .withSourcePath("data-import/test-key-response")
+              )
               .toString()
           )
         )
@@ -44,7 +47,33 @@ public class DownloadUrlAPITest extends AbstractRestTest {
       .get(DOWNLOAD_URL_PATH)
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("url", containsString("test-bucket/test-key-response"));
+      .body("url", containsString("test-bucket/data-import/test-key-response"));
+  }
+
+  @Test
+  public void testOutOfScopeRequest() {
+    WireMock.stubFor(
+      get("/change-manager/jobExecutions/" + JOB_EXEC_ID)
+        .willReturn(
+          okJson(
+            JsonObject
+              .mapFrom(
+                new JobExecution()
+                  .withSourcePath("not-correct-prefix/test-key-response")
+              )
+              .toString()
+          )
+        )
+    );
+
+    RestAssured
+      .given()
+      .spec(spec)
+      .when()
+      .pathParam("jobExecutionId", JOB_EXEC_ID)
+      .get(DOWNLOAD_URL_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_NOT_FOUND);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/UploadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/UploadUrlAPITest.java
@@ -33,11 +33,11 @@ public class UploadUrlAPITest extends AbstractRestTest {
       .body(
         "url",
         allOf(
-          matchesRegex(".*/test-bucket/diku/\\d+-test-name.*"),
+          matchesRegex(".*/test-bucket/data-import/diku/\\d+-test-name.*"),
           containsString("partNumber=1")
         )
       )
-      .body("key", matchesRegex("^diku/[0-9]+-test-name$"))
+      .body("key", matchesRegex("^data-import/diku/[0-9]+-test-name$"))
       .body("uploadId", notNullValue());
   }
 
@@ -47,7 +47,7 @@ public class UploadUrlAPITest extends AbstractRestTest {
       .given()
       .spec(spec)
       .when()
-      .queryParam("key", "diku/1234-test-name")
+      .queryParam("key", "data-import/diku/1234-test-name")
       .queryParam("uploadId", "upload-id-here")
       .queryParam("partNumber", "5")
       .get(UPLOAD_URL_CONTINUE_PATH)
@@ -56,12 +56,26 @@ public class UploadUrlAPITest extends AbstractRestTest {
       .body(
         "url",
         allOf(
-          containsString("/test-bucket/diku/1234-test-name"),
+          containsString("/test-bucket/data-import/diku/1234-test-name"),
           containsString("partNumber=5"),
           containsString("uploadId=upload-id-here")
         )
       )
-      .body("key", is(equalTo("diku/1234-test-name")))
+      .body("key", is(equalTo("data-import/diku/1234-test-name")))
       .body("uploadId", is(equalTo("upload-id-here")));
+  }
+
+  @Test
+  public void testBadSubsequentRequest() {
+    RestAssured
+      .given()
+      .spec(spec)
+      .when()
+      .queryParam("key", "invalid-key-out-of-permitted-folder")
+      .queryParam("uploadId", "upload-id-here")
+      .queryParam("partNumber", "5")
+      .get(UPLOAD_URL_CONTINUE_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
   }
 }

--- a/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
+++ b/src/test/java/org/folio/service/s3storage/MinioStorageServiceTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -20,8 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
-import org.folio.rest.jaxrs.model.FileDownloadInfo;
-import org.folio.rest.jaxrs.model.FileUploadInfo;
 import org.folio.s3.client.FolioS3Client;
 import org.folio.s3.exception.S3ClientException;
 import org.junit.Before;
@@ -36,7 +33,7 @@ public class MinioStorageServiceTest {
 
   private final Vertx vertx = Vertx.vertx();
 
-  private static final String S3_FILE_KEY = "test-key";
+  private static final String S3_TEST_KEY = "data-import/test-key";
 
   @Mock
   private FolioS3ClientFactory folioS3ClientFactory;
@@ -70,35 +67,34 @@ public class MinioStorageServiceTest {
     )
       .thenReturn("upload-url");
 
-    Future<FileUploadInfo> result = minioStorageService.getFileUploadFirstPartUrl(
-      "test-file",
-      "test-tenant"
-    );
+    minioStorageService
+      .getFileUploadFirstPartUrl("test-file", "test-tenant")
+      .onComplete(
+        context.asyncAssertSuccess(fileInfo -> {
+          verify(folioS3Client, times(1))
+            .initiateMultipartUpload(fileInfo.getKey());
+          verify(folioS3Client, times(1))
+            .getPresignedMultipartUploadUrl(fileInfo.getKey(), "upload-id", 1);
+          Mockito.verifyNoMoreInteractions(folioS3Client);
 
-    result.onComplete(
-      context.asyncAssertSuccess(fileInfo -> {
-        verify(folioS3Client, times(1))
-          .initiateMultipartUpload(fileInfo.getKey());
-        verify(folioS3Client, times(1))
-          .getPresignedMultipartUploadUrl(fileInfo.getKey(), "upload-id", 1);
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-
-        assertEquals(
-          "Presigned URL is returned",
-          "upload-url",
-          fileInfo.getUrl()
-        );
-        assertEquals(
-          "Upload ID is returned",
-          "upload-id",
-          fileInfo.getUploadId()
-        );
-        assertTrue(
-          "Key format is correct",
-          fileInfo.getKey().matches("^test-tenant/\\d*-test-file$")
-        );
-      })
-    );
+          assertEquals(
+            "Presigned URL is returned",
+            "upload-url",
+            fileInfo.getUrl()
+          );
+          assertEquals(
+            "Upload ID is returned",
+            "upload-id",
+            fileInfo.getUploadId()
+          );
+          assertTrue(
+            "Key format is correct",
+            fileInfo
+              .getKey()
+              .matches("^data-import/test-tenant/\\d+-test-file$")
+          );
+        })
+      );
   }
 
   @Test
@@ -108,19 +104,16 @@ public class MinioStorageServiceTest {
     when(folioS3Client.initiateMultipartUpload(anyString()))
       .thenThrow(exception);
 
-    Future<FileUploadInfo> result = minioStorageService.getFileUploadFirstPartUrl(
-      "test-file",
-      "test-tenant"
-    );
+    minioStorageService
+      .getFileUploadFirstPartUrl(S3_TEST_KEY, "test-tenant")
+      .onComplete(
+        context.asyncAssertFailure(err -> {
+          verify(folioS3Client, times(1)).initiateMultipartUpload(anyString());
+          Mockito.verifyNoMoreInteractions(folioS3Client);
 
-    result.onComplete(
-      context.asyncAssertFailure(err -> {
-        verify(folioS3Client, times(1)).initiateMultipartUpload(anyString());
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-
-        assertSame("Fails with correct exception", exception, err);
-      })
-    );
+          assertSame("Fails with correct exception", exception, err);
+        })
+      );
   }
 
   @Test
@@ -138,55 +131,60 @@ public class MinioStorageServiceTest {
     )
       .thenThrow(exception);
 
-    Future<FileUploadInfo> result = minioStorageService.getFileUploadFirstPartUrl(
-      "test-file",
-      "test-tenant"
-    );
+    minioStorageService
+      .getFileUploadFirstPartUrl(S3_TEST_KEY, "test-tenant")
+      .onComplete(
+        context.asyncAssertFailure(err -> {
+          verify(folioS3Client, times(1)).initiateMultipartUpload(anyString());
+          verify(folioS3Client, times(1))
+            .getPresignedMultipartUploadUrl(
+              anyString(),
+              eq("upload-id"),
+              eq(1)
+            );
+          Mockito.verifyNoMoreInteractions(folioS3Client);
 
-    result.onComplete(
-      context.asyncAssertFailure(err -> {
-        verify(folioS3Client, times(1)).initiateMultipartUpload(anyString());
-        verify(folioS3Client, times(1))
-          .getPresignedMultipartUploadUrl(anyString(), eq("upload-id"), eq(1));
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-
-        assertSame("Fails with correct exception", exception, err);
-      })
-    );
+          assertSame("Fails with correct exception", exception, err);
+        })
+      );
   }
 
   @Test
   public void testLaterPartSuccessful(TestContext context) {
     when(
-      folioS3Client.getPresignedMultipartUploadUrl("test-key", "upload-id", 100)
+      folioS3Client.getPresignedMultipartUploadUrl(
+        S3_TEST_KEY,
+        "upload-id",
+        100
+      )
     )
       .thenReturn("upload-url-100");
 
-    Future<FileUploadInfo> result = minioStorageService.getFileUploadPartUrl(
-      "test-key",
-      "upload-id",
-      100
-    );
+    minioStorageService
+      .getFileUploadPartUrl(S3_TEST_KEY, "upload-id", 100)
+      .onComplete(
+        context.asyncAssertSuccess(fileInfo -> {
+          verify(folioS3Client, times(1))
+            .getPresignedMultipartUploadUrl(
+              fileInfo.getKey(),
+              "upload-id",
+              100
+            );
+          Mockito.verifyNoMoreInteractions(folioS3Client);
 
-    result.onComplete(
-      context.asyncAssertSuccess(fileInfo -> {
-        verify(folioS3Client, times(1))
-          .getPresignedMultipartUploadUrl(fileInfo.getKey(), "upload-id", 100);
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-
-        assertEquals(
-          "Presigned URL is returned",
-          "upload-url-100",
-          fileInfo.getUrl()
-        );
-        assertEquals(
-          "Upload ID is returned",
-          "upload-id",
-          fileInfo.getUploadId()
-        );
-        assertEquals("Key did not change", "test-key", fileInfo.getKey());
-      })
-    );
+          assertEquals(
+            "Presigned URL is returned",
+            "upload-url-100",
+            fileInfo.getUrl()
+          );
+          assertEquals(
+            "Upload ID is returned",
+            "upload-id",
+            fileInfo.getUploadId()
+          );
+          assertEquals("Key did not change", S3_TEST_KEY, fileInfo.getKey());
+        })
+      );
   }
 
   @Test
@@ -196,42 +194,43 @@ public class MinioStorageServiceTest {
       testData.getBytes(StandardCharsets.UTF_8)
     );
 
-    Mockito.doReturn(sampleDataStream).when(folioS3Client).read(S3_FILE_KEY);
+    Mockito.doReturn(sampleDataStream).when(folioS3Client).read(S3_TEST_KEY);
 
-    Future<InputStream> result = minioStorageService.readFile(S3_FILE_KEY);
+    minioStorageService
+      .readFile(S3_TEST_KEY)
+      .onComplete(
+        context.asyncAssertSuccess(inStream -> {
+          Mockito.verify(folioS3Client, times(1)).read(S3_TEST_KEY);
+          Mockito.verifyNoMoreInteractions(folioS3Client);
 
-    result.onComplete(
-      context.asyncAssertSuccess(inStream -> {
-        Mockito.verify(folioS3Client, times(1)).read(S3_FILE_KEY);
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-
-        try {
-          assertEquals(
-            testData,
-            IOUtils.toString(inStream, StandardCharsets.UTF_8)
-          );
-        } catch (IOException e) {
-          context.fail("testReadFileSuccessful should not fail");
-        }
-      })
-    );
+          try {
+            assertEquals(
+              "Proper test data is returned",
+              testData,
+              IOUtils.toString(inStream, StandardCharsets.UTF_8)
+            );
+          } catch (IOException e) {
+            context.fail("testReadFileSuccessful should not fail");
+          }
+        })
+      );
   }
 
   @Test
   public void testReadFileFailure(TestContext context) {
     S3ClientException exception = new S3ClientException("test exception");
 
-    Mockito.doThrow(exception).when(folioS3Client).read(S3_FILE_KEY);
+    Mockito.doThrow(exception).when(folioS3Client).read(S3_TEST_KEY);
 
-    Future<InputStream> result = minioStorageService.readFile(S3_FILE_KEY);
-
-    result.onComplete(
-      context.asyncAssertFailure(err -> {
-        Mockito.verify(folioS3Client, times(1)).read(S3_FILE_KEY);
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-        assertSame("Fails with correct exception", exception, err);
-      })
-    );
+    minioStorageService
+      .readFile(S3_TEST_KEY)
+      .onComplete(
+        context.asyncAssertFailure(err -> {
+          Mockito.verify(folioS3Client, times(1)).read(S3_TEST_KEY);
+          Mockito.verifyNoMoreInteractions(folioS3Client);
+          assertSame("Fails with correct exception", exception, err);
+        })
+      );
   }
 
   @Test
@@ -241,23 +240,20 @@ public class MinioStorageServiceTest {
       testData.getBytes(StandardCharsets.UTF_8)
     );
 
-    doReturn(S3_FILE_KEY)
+    doReturn(S3_TEST_KEY)
       .when(folioS3Client)
-      .write(S3_FILE_KEY, sampleDataStream);
+      .write(S3_TEST_KEY, sampleDataStream);
 
-    Future<String> result = minioStorageService.write(
-      S3_FILE_KEY,
-      sampleDataStream
-    );
+    minioStorageService
+      .write(S3_TEST_KEY, sampleDataStream)
+      .onComplete(
+        context.asyncAssertSuccess(path -> {
+          verify(folioS3Client, times(1)).write(S3_TEST_KEY, sampleDataStream);
+          Mockito.verifyNoMoreInteractions(folioS3Client);
 
-    result.onComplete(
-      context.asyncAssertSuccess(path -> {
-        verify(folioS3Client, times(1)).write(S3_FILE_KEY, sampleDataStream);
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-
-        assertEquals(S3_FILE_KEY, path);
-      })
-    );
+          assertEquals("Correct path is returned", S3_TEST_KEY, path);
+        })
+      );
   }
 
   @Test
@@ -269,89 +265,101 @@ public class MinioStorageServiceTest {
 
     S3ClientException exception = new S3ClientException("test exception");
 
-    doThrow(exception).when(folioS3Client).write(S3_FILE_KEY, sampleDataStream);
+    doThrow(exception).when(folioS3Client).write(S3_TEST_KEY, sampleDataStream);
 
-    Future<String> result = minioStorageService.write(
-      S3_FILE_KEY,
-      sampleDataStream
-    );
-
-    result.onComplete(
-      context.asyncAssertFailure(err -> {
-        verify(folioS3Client, times(1)).write(S3_FILE_KEY, sampleDataStream);
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-        assertSame("Fails with correct exception", exception, err);
-      })
-    );
+    minioStorageService
+      .write(S3_TEST_KEY, sampleDataStream)
+      .onComplete(
+        context.asyncAssertFailure(err -> {
+          verify(folioS3Client, times(1)).write(S3_TEST_KEY, sampleDataStream);
+          Mockito.verifyNoMoreInteractions(folioS3Client);
+          assertSame("Fails with correct exception", exception, err);
+        })
+      );
   }
 
   @Test
   public void testRemoveFileSuccessful(TestContext context) throws IOException {
-    Mockito.doReturn(S3_FILE_KEY).when(folioS3Client).remove(S3_FILE_KEY);
+    Mockito.doReturn(S3_TEST_KEY).when(folioS3Client).remove(S3_TEST_KEY);
 
-    Future<Void> result = minioStorageService.remove(S3_FILE_KEY);
-
-    result.onComplete(
-      context.asyncAssertSuccess(_v -> {
-        Mockito.verify(folioS3Client, times(1)).remove(S3_FILE_KEY);
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-      })
-    );
+    minioStorageService
+      .remove(S3_TEST_KEY)
+      .onComplete(
+        context.asyncAssertSuccess(_v -> {
+          Mockito.verify(folioS3Client, times(1)).remove(S3_TEST_KEY);
+          Mockito.verifyNoMoreInteractions(folioS3Client);
+        })
+      );
   }
 
   @Test
   public void testRemoveFileFailure(TestContext context) throws IOException {
     S3ClientException exception = new S3ClientException("test exception");
 
-    Mockito.doThrow(exception).when(folioS3Client).remove(S3_FILE_KEY);
+    Mockito.doThrow(exception).when(folioS3Client).remove(S3_TEST_KEY);
 
-    Future<Void> result = minioStorageService.remove(S3_FILE_KEY);
-
-    result.onComplete(
-      context.asyncAssertFailure(err -> {
-        Mockito.verify(folioS3Client, times(1)).remove(S3_FILE_KEY);
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-        assertSame("Fails with correct exception", exception, err);
-      })
-    );
+    minioStorageService
+      .remove(S3_TEST_KEY)
+      .onComplete(
+        context.asyncAssertFailure(err -> {
+          Mockito.verify(folioS3Client, times(1)).remove(S3_TEST_KEY);
+          Mockito.verifyNoMoreInteractions(folioS3Client);
+          assertSame("Fails with correct exception", exception, err);
+        })
+      );
   }
 
   @Test
   public void testDownloadPresignedSuccessful(TestContext context) {
-    when(folioS3Client.getPresignedUrl("test-file")).thenReturn("download-url");
+    when(folioS3Client.getPresignedUrl(S3_TEST_KEY)).thenReturn("download-url");
 
-    Future<FileDownloadInfo> result = minioStorageService.getFileDownloadUrl(
-      "test-file"
-    );
+    minioStorageService
+      .getFileDownloadUrl(S3_TEST_KEY)
+      .onComplete(
+        context.asyncAssertSuccess(fileInfo -> {
+          verify(folioS3Client, times(1)).getPresignedUrl(S3_TEST_KEY);
+          Mockito.verifyNoMoreInteractions(folioS3Client);
 
-    result.onComplete(
-      context.asyncAssertSuccess(fileInfo -> {
-        verify(folioS3Client, times(1)).getPresignedUrl("test-file");
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-
-        assertEquals(
-          "Presigned URL is returned",
-          "download-url",
-          fileInfo.getUrl()
-        );
-      })
-    );
+          assertEquals(
+            "Presigned URL is returned",
+            "download-url",
+            fileInfo.getUrl()
+          );
+        })
+      );
   }
 
   @Test
   public void testDownloadPresignedFailure(TestContext context) {
-    when(folioS3Client.getPresignedUrl("test-file"))
+    when(folioS3Client.getPresignedUrl(S3_TEST_KEY))
       .thenThrow(new RuntimeException());
 
-    Future<FileDownloadInfo> result = minioStorageService.getFileDownloadUrl(
-      "test-file"
-    );
+    minioStorageService
+      .getFileDownloadUrl(S3_TEST_KEY)
+      .onComplete(
+        context.asyncAssertFailure(_err -> {
+          verify(folioS3Client, times(1)).getPresignedUrl(S3_TEST_KEY);
+          Mockito.verifyNoMoreInteractions(folioS3Client);
+        })
+      );
+  }
 
-    result.onComplete(
-      context.asyncAssertFailure(_err -> {
-        verify(folioS3Client, times(1)).getPresignedUrl("test-file");
-        Mockito.verifyNoMoreInteractions(folioS3Client);
-      })
-    );
+  @Test
+  public void testIncorrectPrefix(TestContext context) throws IOException {
+    minioStorageService
+      .getFileDownloadUrl("not/prefixed/correctly")
+      .onComplete(context.asyncAssertFailure());
+
+    minioStorageService
+      .getFileUploadPartUrl("not/prefixed/correctly", "upload-id", 2)
+      .onComplete(context.asyncAssertFailure());
+
+    minioStorageService
+      .write("not/prefixed/correctly", new ByteArrayInputStream(new byte[1]))
+      .onComplete(context.asyncAssertFailure());
+
+    minioStorageService
+      .remove("not/prefixed/correctly")
+      .onComplete(context.asyncAssertFailure());
   }
 }


### PR DESCRIPTION
# [Jira MODDATAIMP-914](https://issues.folio.org/browse/MODDATAIMP-914)

## Purpose

- Prefix S3 file operations with `data-import/` to improve usability within multi-module buckets

## Approach

- Added checks for this prefix in S3 calls to prevent potential abuse

## Bonus
- Cleaned up MinIO code to remove redundant future returns (can return `executeBlocking` directly as its `Future` form)
  - I also cleaned up the `completeMultipartFileUpload` method to fail on error, rather than succeed with `false`.
  - A majority of the changed lines are due to this as well as cleanup in the associated tests

## Test coverage :100: