### PR TITLE
[MODDATAIMP-913] Resolve race condition in job processing/creation

### DIFF
--- a/src/main/java/org/folio/service/file/SplitFileProcessingService.java
+++ b/src/main/java/org/folio/service/file/SplitFileProcessingService.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.annotation.CheckForNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -120,7 +121,7 @@ public class SplitFileProcessingService {
           params.getTenantId()
         )
       )
-      .andThen(v -> LOGGER.info("Job split and queued successfully!"))
+      .onSuccess(v -> LOGGER.info("Job split and queued successfully!"))
       .onFailure(err -> LOGGER.error("Unable to start job: ", err))
       .mapEmpty();
   }
@@ -182,47 +183,80 @@ public class SplitFileProcessingService {
       params,
       splitInfo.getSplitKeys()
     )
+      .map(childExecs ->
+        childExecs
+          .list()
+          .stream()
+          .map(JobExecution.class::cast)
+          .map(jobExec -> new JobExecutionDto().withId(jobExec.getId()))
+          .collect(Collectors.toList())
+      )
       // update all children
       .compose(childExecs ->
-        fileProcessor.updateJobsProfile(
-          childExecs
-            .list()
-            .stream()
-            .map(JobExecution.class::cast)
-            .map(jobExec -> new JobExecutionDto().withId(jobExec.getId()))
-            .collect(Collectors.toList()),
-          entity.getJobProfileInfo(),
-          params
-        )
+        fileProcessor
+          .updateJobsProfile(childExecs, entity.getJobProfileInfo(), params)
+          // update parent
+          .compose(r ->
+            fileProcessor.updateJobsProfile(
+              Arrays.asList(
+                new JobExecutionDto()
+                  .withId(splitInfo.getJobExecution().getId())
+              ),
+              entity.getJobProfileInfo(),
+              params
+            )
+          )
+          .compose(r ->
+            uploadDefinitionService.updateJobExecutionStatus(
+              splitInfo.getJobExecution().getId(),
+              new StatusDto().withStatus(StatusDto.Status.COMMIT_IN_PROGRESS),
+              params
+            )
+          )
+          .map((Boolean result) -> {
+            if (Boolean.FALSE.equals(result)) {
+              throw new IllegalStateException(
+                "Could not mark job as in progress"
+              );
+            }
+            return result;
+          })
+          .compose(v ->
+            CompositeFuture.all(
+              // we use an IntStream here to have access to i, as the index (and therefore part number)
+              IntStream
+                .range(0, childExecs.size())
+                .mapToObj(i -> {
+                  JobExecutionDto execution = childExecs.get(i);
+                  return queueItemDao.addQueueItem(
+                    new DataImportQueueItem()
+                      .withId(UUID.randomUUID().toString())
+                      .withJobExecutionId(execution.getId())
+                      .withUploadDefinitionId(
+                        entity.getUploadDefinition().getId()
+                      )
+                      .withTenant(params.getTenantId())
+                      .withOriginalSize(splitInfo.getTotalRecords())
+                      .withFilePath(execution.getFileName())
+                      .withTimestamp(new Date())
+                      .withPartNumber(i + 1)
+                      .withProcessing(false)
+                      .withOkapiUrl(params.getOkapiUrl())
+                      .withDataType(
+                        entity.getJobProfileInfo().getDataType().toString()
+                      )
+                  );
+                })
+                .map(Future.class::cast)
+                .collect(Collectors.toList())
+            )
+          )
       )
-      // update parent
-      .compose(r ->
-        fileProcessor.updateJobsProfile(
-          Arrays.asList(
-            new JobExecutionDto().withId(splitInfo.getJobExecution().getId())
-          ),
-          entity.getJobProfileInfo(),
-          params
-        )
-      )
-      .compose(r ->
-        uploadDefinitionService.updateJobExecutionStatus(
-          splitInfo.getJobExecution().getId(),
-          new StatusDto().withStatus(StatusDto.Status.COMMIT_IN_PROGRESS),
-          params
-        )
-      )
-      .map((Boolean result) -> {
-        if (Boolean.FALSE.equals(result)) {
-          throw new IllegalStateException("Could not mark job as in progress");
-        }
-        return result;
-      })
-      .onFailure(err -> LOGGER.error("Unable to initialize children", err))
-      .<Void>mapEmpty()
-      .andThen(v ->
+      .onSuccess(v ->
         LOGGER.info("Created child job executions for {}", splitInfo.getKey())
-      );
+      )
+      .onFailure(err -> LOGGER.error("Unable to initialize children", err))
+      .mapEmpty();
   }
 
   /**
@@ -264,32 +298,9 @@ public class SplitFileProcessingService {
           getUserIdFromMetadata(parentUploadDefinition.getMetadata())
         );
 
-      // outer scope variable could change before lambda execution, so we make it final here
-      int thisPartNumber = partNumber;
-
       futures.add(
         sendJobExecutionRequest(client, initJobExecutionsRqDto)
           .map(collection -> collection.getJobExecutions().get(0))
-          .compose(execution ->
-            queueItemDao
-              .addQueueItem(
-                new DataImportQueueItem()
-                  .withId(UUID.randomUUID().toString())
-                  .withJobExecutionId(execution.getId())
-                  .withUploadDefinitionId(parentUploadDefinition.getId())
-                  .withTenant(params.getTenantId())
-                  .withOriginalSize(parentJobSize)
-                  .withFilePath(key)
-                  .withTimestamp(new Date())
-                  .withPartNumber(thisPartNumber)
-                  .withProcessing(false)
-                  .withOkapiUrl(params.getOkapiUrl())
-                  .withDataType(jobProfileInfo.getDataType().toString())
-              )
-              // we don't want the queue item, just the execution, so we discard the result
-              // and return the execution from the earlier step
-              .map(v -> execution)
-          )
           .onFailure(err ->
             LOGGER.error(
               "Unable to register split file execution for {}: ",
@@ -382,15 +393,23 @@ public class SplitFileProcessingService {
               .recover(err -> Future.succeededFuture())
           );
 
-          deleteQueueFutures.add(
-            client
-              .putChangeManagerJobExecutionsStatusById(
-                exec.getId(),
-                new StatusDto().withStatus(StatusDto.Status.CANCELLED)
-              )
-              .map(this::verifyOkStatus)
-              .mapEmpty()
-          );
+          switch (exec.getStatus()) {
+            case COMMITTED:
+            case ERROR:
+            case DISCARDED:
+            case CANCELLED:
+              break; // don't cancel jobs that are already completed
+            default:
+              deleteQueueFutures.add(
+                client
+                  .putChangeManagerJobExecutionsStatusById(
+                    exec.getId(),
+                    new StatusDto().withStatus(StatusDto.Status.CANCELLED)
+                  )
+                  .map(this::verifyOkStatus)
+                  .mapEmpty()
+              );
+          }
         }
 
         return CompositeFuture.all(

--- a/src/test/java/org/folio/service/file/SplitFileProcessingServiceRegistrationTest.java
+++ b/src/test/java/org/folio/service/file/SplitFileProcessingServiceRegistrationTest.java
@@ -26,19 +26,12 @@ import org.folio.dataimport.util.RestUtil;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobProfileInfo;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
 public class SplitFileProcessingServiceRegistrationTest
   extends SplitFileProcessingServiceAbstractTest {
-
-  @Before
-  public void mockDao() {
-    when(this.queueItemDao.addQueueItem(any()))
-      .thenReturn(Future.succeededFuture("new-id"));
-  }
 
   @Test
   public void testNoSplitRegistration(TestContext context) {
@@ -118,8 +111,7 @@ public class SplitFileProcessingServiceRegistrationTest
           verify(changeManagerClient, times(1))
             .postChangeManagerJobExecutions(any(), any());
 
-          verify(queueItemDao, times(1)).addQueueItem(any());
-          verifyNoMoreInteractions(queueItemDao);
+          verifyNoInteractions(queueItemDao);
         })
       );
   }
@@ -189,8 +181,7 @@ public class SplitFileProcessingServiceRegistrationTest
           verify(changeManagerClient, times(3))
             .postChangeManagerJobExecutions(any(), any());
 
-          verify(queueItemDao, times(3)).addQueueItem(any());
-          verifyNoMoreInteractions(queueItemDao);
+          verifyNoInteractions(queueItemDao);
         })
       );
   }
@@ -228,7 +219,7 @@ public class SplitFileProcessingServiceRegistrationTest
           verify(changeManagerClient, times(1))
             .postChangeManagerJobExecutions(any(), any());
 
-          verifyNoMoreInteractions(queueItemDao);
+          verifyNoInteractions(queueItemDao);
         })
       );
   }

--- a/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
+++ b/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +44,7 @@ import org.folio.rest.jaxrs.model.ProcessFilesRqDto;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.rest.jaxrs.model.UploadDefinition;
 import org.folio.service.file.SplitFileProcessingService.SplitFileInformation;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.core.io.ClassPathResource;
@@ -53,6 +55,12 @@ public class SplitFileProcessingServiceStartJobTest
   extends SplitFileProcessingServiceAbstractTest {
 
   private static final Resource TEST_FILE = new ClassPathResource("10.mrc");
+
+  @Before
+  public void mockDao() {
+    when(this.queueItemDao.addQueueItem(any()))
+      .thenReturn(Future.succeededFuture("new-id"));
+  }
 
   @Test
   public void testCreateParentJobExecutions(TestContext context) {
@@ -428,6 +436,10 @@ public class SplitFileProcessingServiceStartJobTest
 
           verifyNoMoreInteractions(fileProcessor);
           verifyNoMoreInteractions(uploadDefinitionService);
+
+          verify(queueItemDao, times(2)).addQueueItem(any());
+
+          verifyNoMoreInteractions(queueItemDao);
         })
       );
   }
@@ -477,7 +489,9 @@ public class SplitFileProcessingServiceStartJobTest
           .splitKeys(Arrays.asList("a1", "a2"))
           .build()
       )
-      .onComplete(context.asyncAssertFailure());
+      .onComplete(
+        context.asyncAssertFailure(v -> verifyNoInteractions(queueItemDao))
+      );
   }
 
   @Test


### PR DESCRIPTION
# [Jira MODDATAIMP-913](https://issues.folio.org/browse/MODDATAIMP-913)

## Purpose
Remove the race condition that was possible when a job was created/begun processing.  This was possible since, when jobs were created, they were inserted into the queue before fully initialized; as the background workers process from the queue asynchronously, it was possible for there to be enough of a gap here that a job could be grabbed and processed before being properly initialized.

## Approach
Moved the queue-inserting code to be the last step of job processing/registration.
