### PR TITLE
[MODDATAIMP-921] Handle non-MARC files properly

### DIFF
--- a/src/main/java/org/folio/service/file/SplitFileProcessingService.java
+++ b/src/main/java/org/folio/service/file/SplitFileProcessingService.java
@@ -136,7 +136,7 @@ public class SplitFileProcessingService {
         .getFileDefinitions()
         .stream()
         .map(FileDefinition::getSourcePath)
-        .map(this::splitFile)
+        .map(key -> splitFile(key, entity.getJobProfileInfo()))
         .collect(Collectors.toList())
     );
 
@@ -471,9 +471,15 @@ public class SplitFileProcessingService {
 
   /**
    * Split a file into chunks, returning a {@link SplitFileInformation} object containing
-   * the original key, the total number of records in the file, and the keys of the split chunks
+   * the original key, the total number of records in the file, and the keys of the split chunks.
+   *
+   * Note that non-MARC binary format files will not be split; instead, the keys of the split
+   * chunks will simply be a list containing only the original key
    */
-  protected Future<SplitFileInformation> splitFile(String key) {
+  protected Future<SplitFileInformation> splitFile(
+    String key,
+    JobProfileInfo profile
+  ) {
     return Future
       .succeededFuture(new SplitFileInformation().withKey(key))
       // splitting and counting must be done sequentially as splitting deletes the original file
@@ -483,18 +489,22 @@ public class SplitFileProcessingService {
           .map((InputStream stream) -> {
             try {
               return result.withTotalRecords(
-                FileSplitUtilities.countRecordsInMarcFile(stream)
+                FileSplitUtilities.countRecordsInFile(key, stream, profile)
               );
             } catch (IOException e) {
               throw new UncheckedIOException(e);
             }
           })
       )
-      .compose(result ->
-        fileSplitService
-          .splitFileFromS3(vertx.getOrCreateContext(), key)
-          .map(result::withSplitKeys)
-      );
+      .compose((SplitFileInformation file) -> {
+        if (FileSplitUtilities.isMarcBinary(key, profile)) {
+          return fileSplitService
+            .splitFileFromS3(vertx.getOrCreateContext(), key)
+            .map(file::withSplitKeys);
+        } else {
+          return Future.succeededFuture(file.withSplitKeys(Arrays.asList(key)));
+        }
+      });
   }
 
   protected Buffer verifyOkStatus(HttpResponse<Buffer> response) {

--- a/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
+++ b/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
@@ -202,16 +202,18 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
    * @param jobProfile - job profile main info
    * @return total records in file;
    */
-  //TODO: just quite a contradictory method
-  private int countTotalRecordsInFile(File file, JobProfileInfo jobProfile) {
-    int total = 0;
+  public static int countTotalRecordsInFile(File file, JobProfileInfo jobProfile) {
     if (file == null || jobProfile == null) {
-      return total;
+      return 0;
     }
+
     SourceReader reader = SourceReaderBuilder.build(file, jobProfile);
+
+    int total = 0;
     while (reader.hasNext()) {
       total += reader.next().size();
     }
+
     return total;
   }
 

--- a/src/main/java/org/folio/service/processing/split/FileSplitUtilities.java
+++ b/src/main/java/org/folio/service/processing/split/FileSplitUtilities.java
@@ -1,18 +1,25 @@
 package org.folio.service.processing.split;
 
+import static org.folio.service.processing.reader.MarcJsonReader.JSON_EXTENSION;
+import static org.folio.service.processing.reader.MarcXmlReader.XML_EXTENSION;
+
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.io.FilenameUtils;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
+import org.folio.service.processing.ParallelFileChunkingProcessor;
 
 @UtilityClass
 public class FileSplitUtilities {
 
   public static final byte MARC_RECORD_TERMINATOR = (byte) 0x1d;
-
-  private static final int BUFFER_SIZE = 8192;
 
   /**
    * Creates the S3 key for a split chunk within a larger file
@@ -34,29 +41,39 @@ public class FileSplitUtilities {
   }
 
   /**
-   * Counts records in a given {@link InputStream}, closing it afterwards.
+   * Counts records in a given {@link InputStream}, <strong>closing it afterwards</strong>.
    *
-   * @throws IOException if the stream cannot be read
+   * @throws IOException if the stream cannot be read or a temp file cannot be created
    */
-  public static int countRecordsInMarcFile(InputStream inStream)
-    throws IOException {
-    try {
-      byte[] byteBuffer = new byte[BUFFER_SIZE];
-      int numberOfBytes;
-      int numRecords = 0;
+  public static int countRecordsInFile(
+    String filename,
+    InputStream inStream,
+    JobProfileInfo profile
+  ) throws IOException {
+    File tempFile = Files
+      .createTempFile(
+        "di-tmp-",
+        // later stage requires correct file extension
+        Path.of(filename).getFileName().toString(),
+        PosixFilePermissions.asFileAttribute(
+          PosixFilePermissions.fromString("rwx------")
+        )
+      )
+      .toFile();
 
-      int offset = 0;
-      do {
-        numberOfBytes = inStream.read(byteBuffer, offset, BUFFER_SIZE);
-        for (int i = 0; i < numberOfBytes; i++) if (
-          byteBuffer[i] == MARC_RECORD_TERMINATOR
-        ) {
-          ++numRecords;
-        }
-      } while (numberOfBytes >= 0);
-      return numRecords;
+    try (
+      InputStream autoCloseMe = inStream;
+      OutputStream fileOutputStream = new FileOutputStream(tempFile)
+    ) {
+      inStream.transferTo(fileOutputStream);
+      fileOutputStream.flush();
+
+      return ParallelFileChunkingProcessor.countTotalRecordsInFile(
+        tempFile,
+        profile
+      );
     } finally {
-      inStream.close();
+      Files.deleteIfExists(tempFile.toPath());
     }
   }
 
@@ -66,6 +83,18 @@ public class FileSplitUtilities {
       PosixFilePermissions.asFileAttribute(
         PosixFilePermissions.fromString("rwx------")
       )
+    );
+  }
+
+  public boolean isMarcBinary(String path, JobProfileInfo profile) {
+    if (profile.getDataType() != JobProfileInfo.DataType.MARC) {
+      return false;
+    }
+
+    String extension = FilenameUtils.getExtension(path);
+
+    return (
+      !JSON_EXTENSION.equals(extension) && !XML_EXTENSION.equals(extension)
     );
   }
 }

--- a/src/test/java/org/folio/service/file/SplitFileProcessingServiceAbstractTest.java
+++ b/src/test/java/org/folio/service/file/SplitFileProcessingServiceAbstractTest.java
@@ -79,6 +79,12 @@ public abstract class SplitFileProcessingServiceAbstractTest
     .withId("3c4add55-cb78-5056-860f-5df0d1aa83ca")
     .withSourcePath("key/file-3-key");
 
+  protected static final JobProfileInfo JOB_PROFILE_MARC = new JobProfileInfo()
+    .withDataType(JobProfileInfo.DataType.MARC);
+
+  protected static final JobProfileInfo JOB_PROFILE_EDIFACT = new JobProfileInfo()
+    .withDataType(JobProfileInfo.DataType.EDIFACT);
+
   @Mock
   protected FileSplitService fileSplitService;
 
@@ -173,8 +179,11 @@ public abstract class SplitFileProcessingServiceAbstractTest
       return super.createParentJobExecutions(entity, client);
     }
 
-    public Future<SplitFileInformation> splitFile(String key) {
-      return super.splitFile(key);
+    public Future<SplitFileInformation> splitFile(
+      String key,
+      JobProfileInfo profile
+    ) {
+      return super.splitFile(key, profile);
     }
 
     public Buffer verifyOkStatus(HttpResponse<Buffer> response) {

--- a/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
+++ b/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
@@ -39,6 +39,8 @@ import org.folio.rest.jaxrs.model.File;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.JobExecutionDto;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
+import org.folio.rest.jaxrs.model.JobProfileInfo.DataType;
 import org.folio.rest.jaxrs.model.ProcessFilesRqDto;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.rest.jaxrs.model.UploadDefinition;
@@ -168,7 +170,7 @@ public class SplitFileProcessingServiceStartJobTest
       );
 
     service
-      .splitFile("test-key")
+      .splitFile("test-key", JOB_PROFILE_MARC)
       .onComplete(
         context.asyncAssertSuccess(result -> {
           assertThat(result.getKey(), is("test-key"));
@@ -176,6 +178,27 @@ public class SplitFileProcessingServiceStartJobTest
             result.getSplitKeys(),
             contains("result1", "result2", "result3")
           );
+          assertThat(result.getTotalRecords(), is(10));
+        })
+      );
+  }
+
+  @Test
+  public void testSplitNonMarcFile(TestContext context) throws IOException {
+    when(minioStorageService.readFile("test-key"))
+      .thenReturn(Future.succeededFuture(TEST_FILE.getInputStream()));
+
+    when(fileSplitService.splitFileFromS3(any(), any()))
+      .thenReturn(
+        Future.succeededFuture(Arrays.asList("result1", "result2", "result3"))
+      );
+
+    service
+      .splitFile("test-key", JOB_PROFILE_EDIFACT)
+      .onComplete(
+        context.asyncAssertSuccess(result -> {
+          assertThat(result.getKey(), is("test-key"));
+          assertThat(result.getSplitKeys(), contains("test-key"));
           assertThat(result.getTotalRecords(), is(10));
         })
       );
@@ -195,7 +218,9 @@ public class SplitFileProcessingServiceStartJobTest
         )
       );
 
-    service.splitFile("test-key").onComplete(context.asyncAssertFailure());
+    service
+      .splitFile("test-key", JOB_PROFILE_MARC)
+      .onComplete(context.asyncAssertFailure());
   }
 
   @Test
@@ -231,7 +256,7 @@ public class SplitFileProcessingServiceStartJobTest
         )
       )
       .when(service)
-      .splitFile(any());
+      .splitFile(any(), any());
 
     doAnswer(invocation -> {
         InitJobExecutionsRqDto request = invocation.getArgument(0);
@@ -317,7 +342,7 @@ public class SplitFileProcessingServiceStartJobTest
           );
           assertThat(map.get("key/file-3-key").getTotalRecords(), is(10));
 
-          verify(service, times(3)).splitFile(any());
+          verify(service, times(3)).splitFile(any(), any());
           verify(changeManagerClient, times(1))
             .postChangeManagerJobExecutions(any(), any());
         })

--- a/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
+++ b/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
@@ -53,6 +53,9 @@ public class SplitFileProcessingServiceStartJobTest
   extends SplitFileProcessingServiceAbstractTest {
 
   private static final Resource TEST_FILE = new ClassPathResource("10.mrc");
+  private static final Resource TEST_EDIFACT_FILE = new ClassPathResource(
+    "edifact/CornAuxAm.1605541205.edi"
+  );
 
   @Test
   public void testCreateParentJobExecutions(TestContext context) {
@@ -184,7 +187,7 @@ public class SplitFileProcessingServiceStartJobTest
   @Test
   public void testSplitNonMarcFile(TestContext context) throws IOException {
     when(minioStorageService.readFile("test-key"))
-      .thenReturn(Future.succeededFuture(TEST_FILE.getInputStream()));
+      .thenReturn(Future.succeededFuture(TEST_EDIFACT_FILE.getInputStream()));
 
     when(fileSplitService.splitFileFromS3(any(), any()))
       .thenReturn(
@@ -197,7 +200,7 @@ public class SplitFileProcessingServiceStartJobTest
         context.asyncAssertSuccess(result -> {
           assertThat(result.getKey(), is("test-key"));
           assertThat(result.getSplitKeys(), contains("test-key"));
-          assertThat(result.getTotalRecords(), is(10));
+          assertThat(result.getTotalRecords(), is(1));
         })
       );
   }

--- a/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
+++ b/src/test/java/org/folio/service/file/SplitFileProcessingServiceStartJobTest.java
@@ -39,8 +39,6 @@ import org.folio.rest.jaxrs.model.File;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.JobExecutionDto;
-import org.folio.rest.jaxrs.model.JobProfileInfo;
-import org.folio.rest.jaxrs.model.JobProfileInfo.DataType;
 import org.folio.rest.jaxrs.model.ProcessFilesRqDto;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.rest.jaxrs.model.UploadDefinition;

--- a/src/test/java/org/folio/service/split/FileSplitUtilitiesCountTest.java
+++ b/src/test/java/org/folio/service/split/FileSplitUtilitiesCountTest.java
@@ -9,6 +9,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.service.processing.split.FileSplitUtilities;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,30 +19,47 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class FileSplitUtilitiesCountTest {
 
-  // tuples of [path, number of records]
+  private static final JobProfileInfo MARC_PROFILE = new JobProfileInfo()
+    .withDataType(JobProfileInfo.DataType.MARC);
+  private static final JobProfileInfo EDIFACT_PROFILE = new JobProfileInfo()
+    .withDataType(JobProfileInfo.DataType.EDIFACT);
+
+  // tuples of [path, number of records, profile]
   @Parameters
   public static Collection<Object[]> getCases() {
     return Arrays.asList(
-      new Object[] { "src/test/resources/0.mrc", 0 },
+      new Object[] { "0.mrc", 0, MARC_PROFILE },
       // 1 buffer read
-      new Object[] { "src/test/resources/1.mrc", 1 },
+      new Object[] { "1.mrc", 1, MARC_PROFILE },
       // multiple buffer reads
-      new Object[] { "src/test/resources/100.mrc", 100 },
-      new Object[] { "src/test/resources/2500.mrc", 2500 },
-      new Object[] { "src/test/resources/5000.mrc", 5000 },
-      new Object[] { "src/test/resources/10000.mrc", 10000 },
-      new Object[] { "src/test/resources/22778.mrc", 22778 },
-      new Object[] { "src/test/resources/50000.mrc", 50000 },
-      new Object[] { "src/test/resources/invalidMarcFile.mrc", 0 }
+      new Object[] { "100.mrc", 100, MARC_PROFILE },
+      new Object[] { "2500.mrc", 2500, MARC_PROFILE },
+      new Object[] { "5000.mrc", 5000, MARC_PROFILE },
+      new Object[] { "10000.mrc", 10000, MARC_PROFILE },
+      new Object[] { "22778.mrc", 22778, MARC_PROFILE },
+      new Object[] { "50000.mrc", 50000, MARC_PROFILE },
+      new Object[] { "invalidMarcFile.mrc", 0, MARC_PROFILE },
+      // MARC XML
+      new Object[] { "UChicago_SampleBibs.xml", 62, MARC_PROFILE },
+      // MARC JSON
+      new Object[] { "ChalmersFOLIOExamples.json", 62, MARC_PROFILE },
+      // Edifact
+      new Object[] { "edifact/TAMU-HRSW20200808072013.EDI", 7, EDIFACT_PROFILE }
     );
   }
 
   private String path;
   private int count;
+  private JobProfileInfo profile;
 
-  public FileSplitUtilitiesCountTest(String path, int count) {
-    this.path = path;
+  public FileSplitUtilitiesCountTest(
+    String path,
+    int count,
+    JobProfileInfo profile
+  ) {
+    this.path = "src/test/resources/" + path;
     this.count = count;
+    this.profile = profile;
   }
 
   @Test
@@ -51,7 +69,7 @@ public class FileSplitUtilitiesCountTest {
     );
 
     assertThat(
-      FileSplitUtilities.countRecordsInMarcFile(inputStream),
+      FileSplitUtilities.countRecordsInFile(path, inputStream, profile),
       is(count)
     );
 

--- a/src/test/java/org/folio/service/split/FileSplitUtilitiesIsBinaryMarcTest.java
+++ b/src/test/java/org/folio/service/split/FileSplitUtilitiesIsBinaryMarcTest.java
@@ -1,0 +1,56 @@
+package org.folio.service.split;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
+import org.folio.service.processing.split.FileSplitUtilities;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class FileSplitUtilitiesIsBinaryMarcTest {
+
+  private static final JobProfileInfo MARC_PROFILE = new JobProfileInfo()
+    .withDataType(JobProfileInfo.DataType.MARC);
+  private static final JobProfileInfo EDIFACT_PROFILE = new JobProfileInfo()
+    .withDataType(JobProfileInfo.DataType.EDIFACT);
+
+  // tuples of [path, profile, expected]
+  @Parameters
+  public static Collection<Object[]> getCases() {
+    return Arrays.asList(
+      new Object[] { "test.mrc", MARC_PROFILE, true },
+      new Object[] { "test.mrc21", MARC_PROFILE, true },
+      // specifically excludes MARC JSON/XML
+      new Object[] { "test.json", MARC_PROFILE, false },
+      new Object[] { "test.xml", MARC_PROFILE, false },
+      // non-marc profile takes precedence
+      new Object[] { "test.mrc", EDIFACT_PROFILE, false }
+    );
+  }
+
+  private String path;
+  private JobProfileInfo profile;
+  private boolean expected;
+
+  public FileSplitUtilitiesIsBinaryMarcTest(
+    String path,
+    JobProfileInfo profile,
+    boolean expected
+  ) {
+    this.path = "src/test/resources/" + path;
+    this.profile = profile;
+    this.expected = expected;
+  }
+
+  @Test
+  public void testIsBinaryMarcFile() throws IOException {
+    assertThat(FileSplitUtilities.isMarcBinary(path, profile), is(expected));
+  }
+}

--- a/src/test/java/org/folio/service/split/FileSplitWriterRegularTest.java
+++ b/src/test/java/org/folio/service/split/FileSplitWriterRegularTest.java
@@ -16,12 +16,14 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.service.processing.split.FileSplitUtilities;
 import org.folio.service.processing.split.FileSplitWriter;
 import org.folio.service.processing.split.FileSplitWriterOptions;
@@ -322,7 +324,7 @@ public class FileSplitWriterRegularTest {
                                   assertThat(actual, is(expected));
 
                                   // verify counts of records in each are correct
-                                  int totalRecords = FileSplitUtilities.countRecordsInMarcFile(
+                                  int totalRecords = countRecordsInMarcFile(
                                     new ByteArrayInputStream(actual)
                                   );
 
@@ -334,7 +336,7 @@ public class FileSplitWriterRegularTest {
                                     if (i == fileContents.size() - 1) {
                                       // the last slice should have all remaining records
                                       assertThat(
-                                        FileSplitUtilities.countRecordsInMarcFile(
+                                        countRecordsInMarcFile(
                                           new ByteArrayInputStream(
                                             fileContents.get(i)
                                           )
@@ -344,7 +346,7 @@ public class FileSplitWriterRegularTest {
                                     } else {
                                       // all other slices should have a full chunk
                                       assertThat(
-                                        FileSplitUtilities.countRecordsInMarcFile(
+                                        countRecordsInMarcFile(
                                           new ByteArrayInputStream(
                                             fileContents.get(i)
                                           )
@@ -369,5 +371,13 @@ public class FileSplitWriterRegularTest {
             );
         })
       );
+  }
+
+  private int countRecordsInMarcFile(InputStream stream) throws IOException {
+    return FileSplitUtilities.countRecordsInFile(
+      "placeholder.mrc",
+      stream,
+      new JobProfileInfo().withDataType(JobProfileInfo.DataType.MARC)
+    );
   }
 }


### PR DESCRIPTION
# [Jira MODDATAIMP-921](https://issues.folio.org/browse/MODDATAIMP-921)

## Purpose
Currently, all files were fed through the file-splitting process.  However, this system only supports plain binary MARC files (.mrc); as such, MARC JSON, MARC XML, and EDIFACT records were being misprocessed.

Futhermore, the logic used to calculate the number of records in the file was also assuming its type as binary MARC (.mrc).  This changes this logic to use already implemented logic from the file processing components.

## Approach
This adds utility methods and checks to ensure only binary MARC files (.mrc) are split; all other file types are fed through an alternative workflow.  Additionally, the previously-used MARC record counting was adapted to work with any supported type.

## Coverage: :100: