### PR TITLE
MODCON-92. Populate system users with type='system' in different modules

### DIFF
--- a/src/main/java/org/folio/service/auth/SystemUserAuthService.java
+++ b/src/main/java/org/folio/service/auth/SystemUserAuthService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 public class SystemUserAuthService {
 
   private static final Logger LOGGER = LogManager.getLogger();
+  private static final String SYSTEM_USER_TYPE = "system";
 
   private AuthClient authClient;
   private PermissionsClient permissionsClient;
@@ -207,6 +208,7 @@ public class SystemUserAuthService {
       .id(UUID.randomUUID().toString())
       .active(true)
       .username(username)
+      .type(SYSTEM_USER_TYPE)
       .personal(User.Personal.builder().lastName("SystemDataImport").build())
       .build();
   }

--- a/src/main/java/org/folio/service/auth/UsersClient.java
+++ b/src/main/java/org/folio/service/auth/UsersClient.java
@@ -48,6 +48,7 @@ public class UsersClient extends ApiClient {
 
     private String id;
     private String username;
+    private String type;
     private boolean active;
     private Personal personal;
 


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-92

## Approach
User type is required now in ECS mode, so each system user should have type='system' populated
