### PR TITLE
Add missing permission 

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -189,6 +189,7 @@
             "inventory-storage.items.collection.get",
             "inventory-storage.items.item.post",
             "inventory-storage.items.item.put",
+            "inventory-storage.items.item.get",
             "inventory-storage.material-types.item.get",
             "inventory-storage.material-types.collection.get",
             "inventory-storage.loan-types.item.get",

--- a/src/main/resources/permissions.txt
+++ b/src/main/resources/permissions.txt
@@ -32,6 +32,7 @@ inventory-storage.authority-source-files.collection.get
 inventory-storage.items.collection.get
 inventory-storage.items.item.post
 inventory-storage.items.item.put
+inventory-storage.items.item.get
 inventory-storage.material-types.item.get
 inventory-storage.material-types.collection.get
 inventory-storage.loan-types.item.get


### PR DESCRIPTION
The permission `inventory-storage.items.item.get` is needed to process update jobs, however, it was missing from the endpoint (and the system user, too)