### PR TITLE
[MODDATAIMP-908] 404 not found if a S3 download is requested for a file that no longer exists

### DIFF
--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -507,7 +507,7 @@ public class DataImportImpl implements DataImport {
         .compose(key -> minioStorageService.getFileDownloadUrl(key))
         .map(GetDataImportJobExecutionsDownloadUrlByJobExecutionIdResponse::respond200WithApplicationJson)
         .map(Response.class::cast)
-        .otherwise(vv -> GetDataImportJobExecutionsDownloadUrlByJobExecutionIdResponse.respond404WithTextPlain("Job execution not found"))
+        .otherwise(vv -> GetDataImportJobExecutionsDownloadUrlByJobExecutionIdResponse.respond404WithTextPlain("Not found"))
         .onComplete(asyncResultHandler);
     });
   }

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -99,7 +99,7 @@ public class MinioStorageServiceImpl implements MinioStorageService {
           // ensure the key is present in the bucket
           // to check if it exists, we need to search with "key" as a prefix
           // hence the list() call and array checking
-          if (!client.list(key).stream().anyMatch(key::equals)) {
+          if (client.list(key).stream().noneMatch(key::equals)) {
             blockingFuture.fail(
               new NotFoundException("Key " + key + " is not present in S3")
             );

--- a/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
+++ b/src/main/java/org/folio/service/s3storage/MinioStorageServiceImpl.java
@@ -101,7 +101,9 @@ public class MinioStorageServiceImpl implements MinioStorageService {
           // hence the list() call and array checking
           if (client.list(key).stream().noneMatch(key::equals)) {
             blockingFuture.fail(
-              new NotFoundException("Key " + key + " is not present in S3")
+              LOGGER.throwing(
+                new NotFoundException("Key " + key + " is not present in S3")
+              )
             );
           }
 

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -354,7 +354,7 @@ public abstract class AbstractRestTest {
 
   protected void clearTable(TestContext context) {
     s3Client.createBucketIfNotExists();
-    s3Client.remove(s3Client.list("").toArray(size -> new String[size]));
+    s3Client.remove(s3Client.list(MINIO_BUCKET).toArray(size -> new String[size]));
     PostgresClient.getInstance(vertx, TENANT_ID).delete(FILE_EXTENSIONS_TABLE, new Criterion(), context.asyncAssertSuccess(event1 ->
       PostgresClient.getInstance(vertx, TENANT_ID).delete(UPLOAD_DEFINITIONS_TABLE, new Criterion(), context.asyncAssertSuccess(event2 ->
         PostgresClient.getInstance(vertx).execute("DELETE FROM data_import_global.queue_items;", context.asyncAssertSuccess())

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -94,7 +94,7 @@ public abstract class AbstractRestTest {
   private static final String OKAPI_URL_ENV = "OKAPI_URL";
   private static final int PORT = NetworkUtils.nextFreePort();
   protected static final String OKAPI_URL = "http://localhost:" + PORT;
-  private static final String MINIO_BUCKET = "test-bucket";
+  protected static final String MINIO_BUCKET = "test-bucket";
 
   private static final String GET_USER_URL = "/users?query=id==";
 
@@ -159,7 +159,7 @@ public abstract class AbstractRestTest {
   public static EmbeddedKafkaCluster kafkaCluster;
 
   @Container
-  private static final LocalStackContainer localStackContainer = new LocalStackContainer(
+  protected static final LocalStackContainer localStackContainer = new LocalStackContainer(
     DockerImageName.parse("localstack/localstack:0.11.3")
   )
     .withServices(LocalStackContainer.Service.S3);
@@ -354,7 +354,7 @@ public abstract class AbstractRestTest {
 
   protected void clearTable(TestContext context) {
     s3Client.createBucketIfNotExists();
-    s3Client.remove(s3Client.list(MINIO_BUCKET).toArray(size -> new String[size]));
+    s3Client.remove(s3Client.list("").toArray(size -> new String[size]));
     PostgresClient.getInstance(vertx, TENANT_ID).delete(FILE_EXTENSIONS_TABLE, new Criterion(), context.asyncAssertSuccess(event1 ->
       PostgresClient.getInstance(vertx, TENANT_ID).delete(UPLOAD_DEFINITIONS_TABLE, new Criterion(), context.asyncAssertSuccess(event2 ->
         PostgresClient.getInstance(vertx).execute("DELETE FROM data_import_global.queue_items;", context.asyncAssertSuccess())

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -159,7 +159,7 @@ public abstract class AbstractRestTest {
   public static EmbeddedKafkaCluster kafkaCluster;
 
   @Container
-  protected static final LocalStackContainer localStackContainer = new LocalStackContainer(
+  private static final LocalStackContainer localStackContainer = new LocalStackContainer(
     DockerImageName.parse("localstack/localstack:0.11.3")
   )
     .withServices(LocalStackContainer.Service.S3);

--- a/src/test/java/org/folio/rest/DownloadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/DownloadUrlAPITest.java
@@ -13,11 +13,13 @@ import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.compress.utils.ByteUtils;
 import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.testcontainers.images.builder.Transferable;
 
 @Log4j2
 @RunWith(VertxUnitRunner.class)
@@ -53,7 +55,7 @@ public class DownloadUrlAPITest extends AbstractRestTest {
       Arrays.asList(4, 3, 2, 1),
       Arrays.asList(3, 4, 2, 1),
       Arrays.asList(2, 4, 3, 1),
-      Arrays.asList(4, 2, 3, 1),
+      Arrays.asList(1, 2, 3, 4),
       Arrays.asList(4, 1, 3, 2),
       Arrays.asList(1, 4, 3, 2),
       Arrays.asList(3, 4, 1, 2),
@@ -112,8 +114,12 @@ public class DownloadUrlAPITest extends AbstractRestTest {
         )
     );
 
-    s3Client.write(TEST_KEY, new ByteArrayInputStream(new byte[5]));
-    log.info(s3Client.list(TEST_KEY));
+    s3Client.write(
+      TEST_KEY,
+      new ByteArrayInputStream("test content".getBytes())
+    );
+
+    log.info(s3Client.list(""));
 
     RestAssured
       .given()

--- a/src/test/java/org/folio/rest/DownloadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/DownloadUrlAPITest.java
@@ -20,18 +20,15 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import lombok.extern.log4j.Log4j2;
 import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.AssembleFileDto;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.jaxrs.model.FileUploadInfo;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.UploadDefinition;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-@Log4j2
 @RunWith(VertxUnitRunner.class)
 public class DownloadUrlAPITest extends AbstractRestTest {
 
@@ -51,23 +48,8 @@ public class DownloadUrlAPITest extends AbstractRestTest {
   private static final String JOB_EXEC_ID =
     "f26b4519-edfd-5d32-989b-f591b09bd932";
 
-  @After
-  public void cleanupS3() {
-    log.info(
-      "===================================CLEANUP==================================="
-    );
-    log.info("Cleaning up: {}", s3Client.list(MINIO_BUCKET));
-    s3Client.remove(
-      s3Client.list(MINIO_BUCKET).toArray(size -> new String[size])
-    );
-  }
-
   @Test
   public void testSuccessfulRequest() {
-    log.info(
-      "===================================testSuccessfulRequest==================================="
-    );
-
     UploadDefinition definition = createUploadDefinition();
 
     FileUploadInfo uploadInfo = getFirstPart("test-name");
@@ -105,8 +87,6 @@ public class DownloadUrlAPITest extends AbstractRestTest {
         )
     );
 
-    log.info(s3Client.list(""));
-
     RestAssured
       .given()
       .spec(spec)
@@ -120,9 +100,6 @@ public class DownloadUrlAPITest extends AbstractRestTest {
 
   @Test
   public void testOutOfScopeRequest() {
-    log.info(
-      "===================================testOutOfScopeRequest==================================="
-    );
     WireMock.stubFor(
       get("/change-manager/jobExecutions/" + JOB_EXEC_ID)
         .willReturn(
@@ -149,9 +126,6 @@ public class DownloadUrlAPITest extends AbstractRestTest {
 
   @Test
   public void testMissingJobExecutionRequest() {
-    log.info(
-      "===================================testMissingJobExecutionRequest==================================="
-    );
     WireMock.stubFor(
       get("/change-manager/jobExecutions/" + JOB_EXEC_ID).willReturn(notFound())
     );
@@ -168,9 +142,6 @@ public class DownloadUrlAPITest extends AbstractRestTest {
 
   @Test
   public void testMissingFileFromS3Request() {
-    log.info(
-      "===================================testMissingFileFromS3Request==================================="
-    );
     WireMock.stubFor(
       get("/change-manager/jobExecutions/" + JOB_EXEC_ID)
         .willReturn(

--- a/src/test/java/org/folio/rest/DownloadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/DownloadUrlAPITest.java
@@ -42,7 +42,7 @@ public class DownloadUrlAPITest extends AbstractRestTest {
   @Test
   public void testRunner() {
     List<List<Integer>> cases = Arrays.asList(
-      Arrays.asList(1, 2, 3, 4),
+      Arrays.asList(4, 2, 3, 1),
       Arrays.asList(2, 1, 3, 4),
       Arrays.asList(3, 1, 2, 4),
       Arrays.asList(1, 3, 2, 4),
@@ -113,6 +113,7 @@ public class DownloadUrlAPITest extends AbstractRestTest {
     );
 
     s3Client.write(TEST_KEY, new ByteArrayInputStream(new byte[5]));
+    log.info(s3Client.list(TEST_KEY));
 
     RestAssured
       .given()


### PR DESCRIPTION
# [Jira MODDATAIMP-908](https://issues.folio.org/browse/MODDATAIMP-908)

## Purpose
Getting a presigned URL does not implicitly check that a file exists on S3, which made it possible for download links to be returned for files that no longer exists.  This changes this to only return links when the file is available in S3.

## Approach
Adds a check by calling [ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html) in S3 before returning a download URL. If the object does not exist, no URL is returned.

## Coverage: :100: