### PR TITLE
MODDATAIMP-871 Upgrade folio-kafka-wrapper to 3.0.0 version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2023-09-xo v2.8.0-SNAPSHOT
+* [MODDATAIMP-871](https://issues.folio.org/browse/MODDATAIMP-871) Upgrade folio-kafka-wrapper to 3.0.0 version
+
 ## 2023-03-xo v2.8.0-SNAPSHOT
 * [MODDATAIMP-854](https://issues.folio.org/browse/MODDATAIMP-854) Upgrade mod-data-import to Java 17
 

--- a/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
+++ b/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
@@ -179,14 +179,15 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
     KafkaProducer<String, String> producer = new SimpleKafkaProducerManager(vertx, kafkaConfig).createShared(eventType);
     readStreamWrapper.pipeTo(new WriteStreamWrapper(producer))
       .<Void>mapEmpty()
-      .eventually(x->producer.flush())
-      .eventually(x->producer.close())
+      .eventually(x -> producer.flush())
+      .eventually(x -> producer.close())
       .onSuccess(res -> {
         LOGGER.info("processFile:: Sending event to Kafka finished. jobProfile: {}, eventType: {}", jobProfile, eventType);
         processFilePromise.complete();
       })
-      .onFailure(err -> {LOGGER.warn("processFile:: Error sending event to Kafka. jobProfile: {}, eventType: {}", jobProfile, eventType, err.getCause());
-      processFilePromise.fail(err);
+      .onFailure(err -> {
+        LOGGER.warn("processFile:: Error sending event to Kafka. jobProfile: {}, eventType: {}", jobProfile, eventType, err.getCause());
+        processFilePromise.fail(err);
       });
     return processFilePromise.future();
   }

--- a/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
+++ b/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
@@ -11,6 +11,7 @@ import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.kafka.services.KafkaProducerRecordBuilder;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
 import org.folio.rest.jaxrs.model.InitialRecord;
@@ -190,8 +191,12 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
     int chunkNumber = ++messageCounter;
     String key = String.valueOf(chunkNumber % maxDistributionNum);
 
-    KafkaProducerRecord<String, String> record =
-      KafkaProducerRecord.create(topicName, key, Json.encode(event));
+    var record = new
+      KafkaProducerRecordBuilder<String, Object>(event.getEventMetadata().getTenantId())
+      .key(key)
+      .value(event)
+      .topic(topicName)
+      .build();
 
     record.addHeaders(kafkaHeaders);
 

--- a/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
+++ b/src/main/java/org/folio/service/processing/kafka/SourceReaderReadStreamWrapper.java
@@ -191,25 +191,25 @@ public class SourceReaderReadStreamWrapper implements ReadStream<KafkaProducerRe
     int chunkNumber = ++messageCounter;
     String key = String.valueOf(chunkNumber % maxDistributionNum);
 
-    var record = new
+    var producerRecord = new
       KafkaProducerRecordBuilder<String, Object>(event.getEventMetadata().getTenantId())
       .key(key)
       .value(event)
       .topic(topicName)
       .build();
 
-    record.addHeaders(kafkaHeaders);
+    producerRecord.addHeaders(kafkaHeaders);
 
-    record.addHeader("jobExecutionId", jobExecutionId);
-    record.addHeader("chunkId", chunk.getId());
-    record.addHeader("chunkNumber", String.valueOf(chunkNumber));
+    producerRecord.addHeader("jobExecutionId", jobExecutionId);
+    producerRecord.addHeader("chunkId", chunk.getId());
+    producerRecord.addHeader("chunkNumber", String.valueOf(chunkNumber));
 
     if (chunk.getRecordsMetadata().getLast()) {
-      record.addHeader(END_SENTINEL, "true");
+      producerRecord.addHeader(END_SENTINEL, "true");
     }
 
     LOGGER.debug("createKafkaProducerRecord:: Next chunk has been created: chunkId: {} chunkNumber: {}", chunk.getId(), chunkNumber);
-    return record;
+    return producerRecord;
   }
 
   private void check() {

--- a/src/main/java/org/folio/service/util/EventHandlingUtil.java
+++ b/src/main/java/org/folio/service/util/EventHandlingUtil.java
@@ -3,7 +3,6 @@ package org.folio.service.util;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.Json;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
@@ -12,6 +11,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.SimpleKafkaProducerManager;
+import org.folio.kafka.services.KafkaProducerRecordBuilder;
 import org.folio.processing.events.utils.PomReaderUtil;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
@@ -62,22 +63,22 @@ public final class EventHandlingUtil {
     String recordId = extractHeader(kafkaHeaders, "recordId");
 
     String producerName = eventType + "_Producer";
-    KafkaProducer<String, String> producer =
-      KafkaProducer.createShared(vertx, producerName, kafkaConfig.getProducerProps());
-    producer.write(record)
+
+    KafkaProducer<String, String> producer = new SimpleKafkaProducerManager(vertx, kafkaConfig).createShared(eventType);
+    producer.send(record)
       .<Void>mapEmpty()
-      .eventually(x -> producer.flush())
-      .eventually(x -> producer.close())
-      .onComplete(war -> {
-        if (war.succeeded()) {
-          logSendingSucceeded(eventType, chunkId, recordId);
-          promise.complete(true);
-        } else {
-          Throwable cause = war.cause();
-          LOGGER.warn("{} write error for event {}:", producerName, eventType, cause);
-          promise.fail(cause);
-        }
+      .eventually(x->producer.flush())
+      .eventually(x->producer.close())
+      .onSuccess(arg ->
+      {
+        logSendingSucceeded(eventType, chunkId, recordId);
+        promise.complete();
+      }).onFailure(err -> {
+        Throwable cause = err.getCause();
+        LOGGER.warn("{} write error for event {}:", producerName, eventType, cause);
+        promise.fail(cause);
       });
+
     return promise.future();
   }
 
@@ -98,7 +99,12 @@ public final class EventHandlingUtil {
   }
 
   public static KafkaProducerRecord<String, String> createProducerRecord(Event event, String key, String topicName, List<KafkaHeader> kafkaHeaders) {
-    KafkaProducerRecord<String, String> record = KafkaProducerRecord.create(topicName, key, Json.encode(event));
+    var record = new KafkaProducerRecordBuilder<String, Object>(event.getEventMetadata().getTenantId())
+      .key(key)
+      .value(event)
+      .topic(topicName)
+      .build();
+
     record.addHeaders(kafkaHeaders);
     return record;
   }

--- a/src/main/java/org/folio/service/util/EventHandlingUtil.java
+++ b/src/main/java/org/folio/service/util/EventHandlingUtil.java
@@ -55,7 +55,7 @@ public final class EventHandlingUtil {
 
     String topicName = createTopicName(eventType, tenantId, kafkaConfig);
 
-    KafkaProducerRecord<String, String> record = createProducerRecord(event, key, topicName, kafkaHeaders);
+    KafkaProducerRecord<String, String> producerRecord = createProducerRecord(event, key, topicName, kafkaHeaders);
 
     Promise<Boolean> promise = Promise.promise();
 
@@ -65,7 +65,7 @@ public final class EventHandlingUtil {
     String producerName = eventType + "_Producer";
 
     KafkaProducer<String, String> producer = new SimpleKafkaProducerManager(vertx, kafkaConfig).createShared(eventType);
-    producer.send(record)
+    producer.send(producerRecord)
       .<Void>mapEmpty()
       .eventually(x->producer.flush())
       .eventually(x->producer.close())
@@ -99,14 +99,14 @@ public final class EventHandlingUtil {
   }
 
   public static KafkaProducerRecord<String, String> createProducerRecord(Event event, String key, String topicName, List<KafkaHeader> kafkaHeaders) {
-    var record = new KafkaProducerRecordBuilder<String, Object>(event.getEventMetadata().getTenantId())
+    var producerRecord = new KafkaProducerRecordBuilder<String, Object>(event.getEventMetadata().getTenantId())
       .key(key)
       .value(event)
       .topic(topicName)
       .build();
 
-    record.addHeaders(kafkaHeaders);
-    return record;
+    producerRecord.addHeaders(kafkaHeaders);
+    return producerRecord;
   }
 
   public static String createTopicName(String eventType, String tenantId, KafkaConfig kafkaConfig) {


### PR DESCRIPTION
## Purpose
Upgrade folio-kafka-wrapper to 3.0.0 version
## Approach
Upgrade the version of folio-kafka-wrapper to 3.0.0-SNAPSHOT. Check out the readme at https://github.com/folio-org/folio-kafka-wrapper/blob/master/README.md for usage.

Acceptance Criteria
- kafka records are built using KafkaProducerRecordBuilder
- topic names are generated using KafkaTopicNameHelper
