### PR TITLE
[MODDATAIMP-940] [Poppy] Remove system user default password

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,21 +198,21 @@ For information on what these mean, how to configure them, how scores are calcul
 ## System user
 
 > [!WARNING]
-> This module creates a system user upon installation with the following:
+> This module creates a system user upon installation with the following (if splitting is enabled):
 >
 > - Name `SystemDataImport`
 > - Username `data-import-system-user` (customizable via env variable `SYSTEM_PROCESSING_USERNAME`)
-> - Password `data-import-system-user` (customizable via env variable `SYSTEM_PROCESSING_PASSWORD`)
+> - Password customizable via env variable `SYSTEM_PROCESSING_PASSWORD` (**must be set, or the module will fail to start**)
 > - [permissions to perform any import-related activities](/src/main/resources/permissions.txt).
 
 To enable asynchronous job launching (as part of the file splitting process), the module creates
 a system user upon installation. The system user is named `SystemDataImport`,
 and its credentials may be customized with the following environment variables:
 
-| Name                         | Type   | Required | Default                   | Description          |
-| ---------------------------- | ------ | -------- | ------------------------- | -------------------- |
-| `SYSTEM_PROCESSING_USERNAME` | string | no       | `data-import-system-user` | System user username |
-| `SYSTEM_PROCESSING_PASSWORD` | string | no       | `data-import-system-user` | System user password |
+| Name                         | Type   | Required                     | Default                   | Description          |
+| ---------------------------- | ------ | ---------------------------- | ------------------------- | -------------------- |
+| `SYSTEM_PROCESSING_USERNAME` | string | no                           | `data-import-system-user` | System user username |
+| `SYSTEM_PROCESSING_PASSWORD` | string | yes, if splitting is enabled | _none_                    | System user password |
 
 This user is granted [many of the same permissions](/src/main/resources/permissions.txt) as the module for the
 `/data-import/uploadDefinitions/{uploadDefinitionId}/processFiles` endpoint. This enables this

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -346,6 +346,7 @@
             "users.item.post",
             "users.item.put",
             "login.item.post",
+            "login.item.delete",
             "perms.users.get",
             "perms.users.assign.immutable",
             "perms.users.item.post",
@@ -520,7 +521,6 @@
       { "name": "SCORE_PART_NUMBER_LAST", "value": "0" },
       { "name": "SCORE_PART_NUMBER_LAST_REFERENCE", "value": "100" },
       { "name": "SYSTEM_PROCESSING_USERNAME", "value": "data-import-system-user" },
-      { "name": "SYSTEM_PROCESSING_PASSWORD", "value": "data-import-system-user" },
       { "name": "ASYNC_PROCESSOR_POLL_INTERVAL_MS", "value": "5000" },
       { "name": "ASYNC_PROCESSOR_MAX_WORKERS_COUNT", "value": "1" }
     ]

--- a/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -19,6 +19,7 @@ import org.folio.service.cleanup.StorageCleanupService;
 import org.folio.service.fileextension.FileExtensionService;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 public class ModTenantAPI extends TenantAPI {
 
@@ -36,13 +37,18 @@ public class ModTenantAPI extends TenantAPI {
   @Autowired
   private SystemUserAuthService systemUserAuthService;
 
+  @Value("${SPLIT_FILES_ENABLED:false}")
+  private boolean fileSplittingEnabled;
+
   public ModTenantAPI() {
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
   }
 
   @Override
   Future<Integer> loadData(TenantAttributes attributes, String tenantId, Map<String, String> headers, Context context) {
-    systemUserAuthService.initializeSystemUser(headers);
+    if (fileSplittingEnabled) {
+      systemUserAuthService.initializeSystemUser(headers);
+    }
     return super.loadData(attributes, tenantId, headers, context)
       .compose(num -> {
         initStorageCleanupService(headers, context);

--- a/src/main/java/org/folio/service/auth/ApiClient.java
+++ b/src/main/java/org/folio/service/auth/ApiClient.java
@@ -9,23 +9,20 @@ import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import javax.ws.rs.core.MediaType;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
@@ -35,29 +32,75 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
 
-public abstract class ApiClient {
+public class ApiClient {
 
   private static final Logger LOGGER = LogManager.getLogger(ApiClient.class);
 
   private static ObjectMapper mapper = new ObjectMapper();
 
-  protected Optional<JsonObject> get(
+  protected <T> T sendRequest(
+    HttpRequestBase request,
     OkapiConnectionParams params,
     String endpoint,
-    Map<String, String> query
+    Map<String, String> query,
+    Function<HttpResponse, T> responseMapper
   ) {
-    HttpGet request = new HttpGet();
+    addOkapiHeaders(request, params);
+    setUrl(request, params, endpoint, query);
+    return dispatchRequest(request, responseMapper);
+  }
 
+  protected <T> T sendRequest(
+    HttpEntityEnclosingRequestBase request,
+    OkapiConnectionParams params,
+    String endpoint,
+    Map<String, String> query,
+    Object payload,
+    Function<HttpResponse, T> responseMapper
+  ) {
+    addOkapiHeaders(request, params);
+    setUrl(request, params, endpoint, query);
+    addPayload(request, payload);
+    return dispatchRequest(request, responseMapper);
+  }
+
+  private static void addOkapiHeaders(
+    HttpRequestBase request,
+    OkapiConnectionParams params
+  ) {
     request.setHeader(OKAPI_TOKEN_HEADER, params.getToken());
     request.setHeader(OKAPI_TENANT_HEADER, params.getTenantId());
-    request.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-    request.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
+  }
 
+  private static void addPayload(
+    HttpEntityEnclosingRequest request,
+    Object payload
+  ) {
+    if (payload != null) {
+      try {
+        request.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.setEntity(new StringEntity(mapper.writeValueAsString(payload)));
+      } catch (UnsupportedEncodingException | JsonProcessingException e) {
+        LOGGER.error("Invalid payload: ", e);
+        throw new IllegalArgumentException(e);
+      }
+    }
+  }
+
+  private static void setUrl(
+    HttpRequestBase request,
+    OkapiConnectionParams params,
+    String endpoint,
+    Map<String, String> queryParams
+  ) {
+    if (queryParams == null) {
+      queryParams = Map.of();
+    }
     try {
       request.setURI(
         new URIBuilder(String.format("%s/%s", params.getOkapiUrl(), endpoint))
           .addParameters(
-            query
+            queryParams
               .entrySet()
               .stream()
               .map(e -> new BasicNameValuePair(e.getKey(), e.getValue()))
@@ -70,80 +113,13 @@ public abstract class ApiClient {
       LOGGER.error("Invalid URL: ", e);
       throw new IllegalArgumentException(e);
     }
+  }
 
+  private static <T> T dispatchRequest(
+    HttpRequestBase request,
+    Function<HttpResponse, T> responseMapper
+  ) {
     LOGGER.debug("Sending request {}", request);
-
-    try (
-      CloseableHttpResponse response = HttpClients
-        .createDefault()
-        .execute(request)
-    ) {
-      return getResponseEntity(response);
-    } catch (IOException e) {
-      LOGGER.error("Exception while calling {}", request.getURI(), e);
-      throw new UncheckedIOException(e);
-    }
-  }
-
-  protected Optional<JsonObject> post(
-    OkapiConnectionParams params,
-    String endpoint,
-    Object payload
-  ) {
-    return postOrPut(
-      HttpPost::new,
-      params,
-      endpoint,
-      payload,
-      ApiClient::getResponseEntity
-    );
-  }
-
-  protected Optional<JsonObject> put(
-    OkapiConnectionParams params,
-    String endpoint,
-    Object payload
-  ) {
-    return postOrPut(
-      HttpPut::new,
-      params,
-      endpoint,
-      payload,
-      ApiClient::getResponseEntity
-    );
-  }
-
-  protected Optional<JsonObject> postOrPut(
-    Supplier<HttpEntityEnclosingRequestBase> createRequest,
-    OkapiConnectionParams params,
-    String endpoint,
-    Object payload,
-    Function<CloseableHttpResponse, Optional<JsonObject>> responseMapper
-  ) {
-    HttpEntityEnclosingRequestBase request = createRequest.get();
-
-    request.setHeader(OKAPI_TOKEN_HEADER, params.getToken());
-    request.setHeader(OKAPI_TENANT_HEADER, params.getTenantId());
-    request.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-    request.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
-
-    try {
-      request.setEntity(new StringEntity(mapper.writeValueAsString(payload)));
-    } catch (UnsupportedEncodingException | JsonProcessingException e) {
-      LOGGER.error("Invalid payload: ", e);
-      throw new IllegalArgumentException(e);
-    }
-
-    try {
-      request.setURI(
-        new URI(String.format("%s/%s", params.getOkapiUrl(), endpoint))
-      );
-    } catch (URISyntaxException e) {
-      LOGGER.error("Invalid URL: ", e);
-      throw new IllegalArgumentException(e);
-    }
-
-    LOGGER.debug("Sending request {} with payload {}", request, payload);
 
     try (
       CloseableHttpResponse response = HttpClients
@@ -157,15 +133,18 @@ public abstract class ApiClient {
     }
   }
 
+  protected static boolean isResponseOk(HttpResponse response) {
+    return (
+      response.getStatusLine().getStatusCode() >= HttpStatus.SC_OK &&
+      response.getStatusLine().getStatusCode() < HttpStatus.SC_BAD_REQUEST
+    );
+  }
+
   protected static Optional<JsonObject> getResponseEntity(
     HttpResponse response
   ) {
     HttpEntity entity = response.getEntity();
-    if (
-      response.getStatusLine().getStatusCode() >= HttpStatus.SC_OK &&
-      response.getStatusLine().getStatusCode() < HttpStatus.SC_BAD_REQUEST &&
-      entity != null
-    ) {
+    if (isResponseOk(response) && entity != null) {
       String body;
 
       try {

--- a/src/main/java/org/folio/service/auth/AuthClient.java
+++ b/src/main/java/org/folio/service/auth/AuthClient.java
@@ -2,13 +2,15 @@ package org.folio.service.auth;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import java.util.Optional;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.okapi.common.WebClientFactory;
 import org.folio.okapi.common.refreshtoken.client.ClientOptions;
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuthClient extends ApiClient {
 
+  private static final Logger LOGGER = LogManager.getLogger();
   private static final String CREDENTIALS_ENDPOINT = "authn/credentials";
 
   private static final int CACHE_SIZE = 5;
@@ -56,23 +59,36 @@ public class AuthClient extends ApiClient {
     LoginCredentials payload
   ) {
     if (
-      postOrPut(
-        HttpPost::new,
-        params,
-        CREDENTIALS_ENDPOINT,
-        payload,
-        r -> {
-          // return optional so it can be caught and handled after
-          if (r.getStatusLine().getStatusCode() == 201) {
-            return Optional.of(new JsonObject());
-          } else {
-            return Optional.empty();
-          }
-        }
+      Boolean.FALSE.equals(
+        sendRequest(
+          new HttpPost(),
+          params,
+          CREDENTIALS_ENDPOINT,
+          null,
+          payload,
+          ApiClient::isResponseOk
+        )
       )
-        .isEmpty()
     ) {
-      throw new IllegalStateException();
+      throw new IllegalStateException("Unable to save credentials");
+    }
+  }
+
+  public void deleteCredentials(OkapiConnectionParams params, String userId) {
+    if (
+      Boolean.TRUE.equals(
+        sendRequest(
+          new HttpDelete(),
+          params,
+          CREDENTIALS_ENDPOINT,
+          Map.of("userId", userId),
+          ApiClient::isResponseOk
+        )
+      )
+    ) {
+      LOGGER.info("Deleted existing credentials for system user");
+    } else {
+      LOGGER.warn("Unable to delete existing credentials for system user");
     }
   }
 
@@ -82,9 +98,28 @@ public class AuthClient extends ApiClient {
   @AllArgsConstructor
   public static class LoginCredentials {
 
-    private String userId;
     private String username;
     private String password;
     private String tenant;
+
+    public String toString() {
+      if (this.getPassword().isBlank()) {
+        return (
+          "LoginCredentials(username=" +
+          this.getUsername() +
+          ", password=<not set>, tenant=" +
+          this.getTenant() +
+          ")"
+        );
+      } else {
+        return (
+          "LoginCredentials(username=" +
+          this.getUsername() +
+          ", password=<set>, tenant=" +
+          this.getTenant() +
+          ")"
+        );
+      }
+    }
   }
 }

--- a/src/main/java/org/folio/service/auth/AuthClient.java
+++ b/src/main/java/org/folio/service/auth/AuthClient.java
@@ -101,25 +101,5 @@ public class AuthClient extends ApiClient {
     private String username;
     private String password;
     private String tenant;
-
-    public String toString() {
-      if (this.getPassword().isBlank()) {
-        return (
-          "LoginCredentials(username=" +
-          this.getUsername() +
-          ", password=<not set>, tenant=" +
-          this.getTenant() +
-          ")"
-        );
-      } else {
-        return (
-          "LoginCredentials(username=" +
-          this.getUsername() +
-          ", password=<set>, tenant=" +
-          this.getTenant() +
-          ")"
-        );
-      }
-    }
   }
 }

--- a/src/main/java/org/folio/service/auth/PermissionsClient.java
+++ b/src/main/java/org/folio/service/auth/PermissionsClient.java
@@ -9,6 +9,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.springframework.stereotype.Component;
 
@@ -22,10 +25,12 @@ public class PermissionsClient extends ApiClient {
     OkapiConnectionParams params,
     String userId
   ) {
-    return get(
+    return sendRequest(
+      new HttpGet(),
       params,
       BASE_ENDPOINT,
-      Map.of("query", String.format("userId==%s", userId))
+      Map.of("query", String.format("userId==%s", userId)),
+      ApiClient::getResponseEntity
     )
       .orElseThrow()
       .getJsonArray("permissionUsers")
@@ -39,7 +44,14 @@ public class PermissionsClient extends ApiClient {
     OkapiConnectionParams okapiConnectionParams,
     PermissionUser permissionUser
   ) {
-    return post(okapiConnectionParams, BASE_ENDPOINT, permissionUser)
+    return sendRequest(
+      new HttpPost(),
+      okapiConnectionParams,
+      BASE_ENDPOINT,
+      null,
+      permissionUser,
+      ApiClient::getResponseEntity
+    )
       .orElseThrow()
       .mapTo(PermissionUser.class);
   }
@@ -48,10 +60,13 @@ public class PermissionsClient extends ApiClient {
     OkapiConnectionParams okapiConnectionParams,
     PermissionUser permissionUser
   ) {
-    return put(
+    return sendRequest(
+      new HttpPut(),
       okapiConnectionParams,
       String.format(BASE_ENDPOINT_WITH_ID, permissionUser.getId()),
-      permissionUser
+      null,
+      permissionUser,
+      ApiClient::getResponseEntity
     )
       .orElseThrow()
       .mapTo(PermissionUser.class);

--- a/src/main/java/org/folio/service/auth/SystemUserAuthService.java
+++ b/src/main/java/org/folio/service/auth/SystemUserAuthService.java
@@ -9,11 +9,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.Getter;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
@@ -30,6 +32,8 @@ public class SystemUserAuthService {
 
   private static final Logger LOGGER = LogManager.getLogger();
   private static final String SYSTEM_USER_TYPE = "system";
+
+  private boolean fileSplittingEnabled;
 
   private AuthClient authClient;
   private PermissionsClient permissionsClient;
@@ -49,11 +53,19 @@ public class SystemUserAuthService {
     @Value(
       "${SYSTEM_PROCESSING_USERNAME:data-import-system-user}"
     ) String username,
-    @Value(
-      "${SYSTEM_PROCESSING_PASSWORD:data-import-system-user}"
-    ) String password,
+    @Value("${SYSTEM_PROCESSING_PASSWORD:}") String password,
+    @Value("${SPLIT_FILES_ENABLED:false}") boolean fileSplittingEnabled,
     @Value("classpath:permissions.txt") Resource permissionsResource
   ) {
+    // ensure password is set properly
+    if (fileSplittingEnabled && StringUtils.isEmpty(password)) {
+      throw new IllegalArgumentException(
+        "System user password must be provided when file splitting is enabled (env variable SYSTEM_PROCESSING_PASSWORD)"
+      );
+    }
+
+    this.fileSplittingEnabled = fileSplittingEnabled;
+
     this.authClient = authClient;
     this.permissionsClient = permissionsClient;
     this.usersClient = usersClient;
@@ -82,7 +94,19 @@ public class SystemUserAuthService {
     }
   }
 
+  private void ensureSplittingEnabled() {
+    if (!fileSplittingEnabled) {
+      throw LOGGER.throwing(
+        new IllegalStateException(
+          "System user is not available unless file splitting is enabled"
+        )
+      );
+    }
+  }
+
   public void initializeSystemUser(Map<String, String> headers) {
+    ensureSplittingEnabled();
+
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(
       headers,
       null
@@ -90,14 +114,47 @@ public class SystemUserAuthService {
 
     User user = getOrCreateSystemUserFromApi(okapiConnectionParams);
     validatePermissions(okapiConnectionParams, user);
-    getAuthToken(okapiConnectionParams);
+    try {
+      getAuthToken(okapiConnectionParams);
+    } catch (NoSuchElementException e) {
+      LOGGER.error("Could not get auth token: ", e);
 
-    LOGGER.info("System user created successfully!");
+      LOGGER.info(
+        "This may be due to a password change...resetting system user password"
+      );
+
+      recoverSystemUserAfterPasswordChange(okapiConnectionParams, user);
+    }
+
+    LOGGER.info("System user created/found successfully!");
+  }
+
+  protected void recoverSystemUserAfterPasswordChange(
+    OkapiConnectionParams params,
+    User user
+  ) {
+    LOGGER.info(
+      "Attempting to delete existing credentials for user {}...",
+      user.getId()
+    );
+    authClient.deleteCredentials(params, user.getId());
+
+    LOGGER.info("Saving new credentials...");
+    authClient.saveCredentials(params, getLoginCredentials(params));
+
+    LOGGER.info("Marking user as active...");
+    user.setActive(true);
+    usersClient.updateUser(params, user);
+
+    LOGGER.info("Verifying we can login...");
+    getAuthToken(params);
   }
 
   public Future<String> getAuthToken(
     OkapiConnectionParams okapiConnectionParams
   ) {
+    ensureSplittingEnabled();
+
     LOGGER.info("Attempting {}", getLoginCredentials(okapiConnectionParams));
 
     return authClient.login(

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -404,6 +404,7 @@ public abstract class AbstractRestTest {
                     null,
                     null,
                     null,
+                    false,
                     new ClassPathResource("permissions.txt")
                   ).getPermissionsList()
                 )

--- a/src/test/java/org/folio/service/auth/ApiClientTest.java
+++ b/src/test/java/org/folio/service/auth/ApiClientTest.java
@@ -178,36 +178,30 @@ public class ApiClientTest {
 
   @Test
   public void testUriException() {
+    HttpPost request = new HttpPost();
     assertThrows(
       IllegalArgumentException.class,
-      () ->
-        client.sendRequest(new HttpPost(), badUriParams, "", null, v -> null)
+      () -> client.sendRequest(request, badUriParams, "", null, v -> null)
     );
   }
 
   @Test
   public void testRequestFailure() {
+    HttpGet request = new HttpGet();
     assertThrows(
       UncheckedIOException.class,
-      () ->
-        client.sendRequest(new HttpGet(), badRequestParams, "", null, v -> null)
+      () -> client.sendRequest(request, badRequestParams, "", null, v -> null)
     );
   }
 
   @Test
   public void testPayloadException() {
     Object obj = new Object();
+    HttpPut request = new HttpPut();
     assertThrows(
       IllegalArgumentException.class,
       () ->
-        client.sendRequest(
-          new HttpPut(),
-          params,
-          "endpoint",
-          null,
-          obj,
-          v -> null
-        )
+        client.sendRequest(request, params, "endpoint", null, obj, v -> null)
     );
   }
 

--- a/src/test/java/org/folio/service/auth/ApiClientTest.java
+++ b/src/test/java/org/folio/service/auth/ApiClientTest.java
@@ -146,6 +146,37 @@ public class ApiClientTest {
   }
 
   @Test
+  public void testEmptyPayload() {
+    // no content-type = no request body
+    mockServer.stubFor(
+      post(urlPathEqualTo("/endpoint"))
+        .withQueryParam("foo", equalTo("bar"))
+        .withHeader("x-okapi-tenant", equalTo("tenant"))
+        .withHeader("x-okapi-token", equalTo("token"))
+        .withHeader("content-type", noValues())
+        .willReturn(okJson(new JsonObject().toString()))
+    );
+
+    client.sendRequest(
+      new HttpPost(),
+      params,
+      "endpoint",
+      Map.of("foo", "bar"),
+      null,
+      ApiClientProxy::getResponseEntity
+    );
+
+    mockServer.verify(
+      1,
+      postRequestedFor(urlPathEqualTo("/endpoint"))
+        .withQueryParam("foo", equalTo("bar"))
+        .withHeader("x-okapi-tenant", equalTo("tenant"))
+        .withHeader("x-okapi-token", equalTo("token"))
+        .withHeader("content-type", noValues())
+    );
+  }
+
+  @Test
   public void testUriException() {
     assertThrows(
       IllegalArgumentException.class,

--- a/src/test/java/org/folio/service/auth/AuthClientTest.java
+++ b/src/test/java/org/folio/service/auth/AuthClientTest.java
@@ -169,9 +169,6 @@ public class AuthClientTest {
     mockServer.stubFor(
       delete(urlPathMatching(CREDENTIALS_ENDPOINT))
         .withQueryParam("userId", equalTo("test-id"))
-        .withRequestBody(
-          equalToJson(JsonObject.mapFrom(testLoginCredentials).toString())
-        )
         .willReturn(created())
     );
 
@@ -188,9 +185,6 @@ public class AuthClientTest {
     mockServer.stubFor(
       delete(urlPathMatching(CREDENTIALS_ENDPOINT))
         .withQueryParam("userId", equalTo("test-id"))
-        .withRequestBody(
-          equalToJson(JsonObject.mapFrom(testLoginCredentials).toString())
-        )
         .willReturn(serverError())
     );
 

--- a/src/test/java/org/folio/service/file/S3JobRunningVerticleEnabledIntegrationTest.java
+++ b/src/test/java/org/folio/service/file/S3JobRunningVerticleEnabledIntegrationTest.java
@@ -19,6 +19,7 @@ public class S3JobRunningVerticleEnabledIntegrationTest
   @BeforeClass
   public static void setUpClass(TestContext context) throws Exception {
     System.setProperty("SPLIT_FILES_ENABLED", "true");
+    System.setProperty("SYSTEM_PROCESSING_PASSWORD", "password");
 
     AbstractRestTest.setUpClass(context);
   }
@@ -26,6 +27,7 @@ public class S3JobRunningVerticleEnabledIntegrationTest
   @AfterClass
   public static void resetEnv() {
     System.clearProperty("SPLIT_FILES_ENABLED");
+    System.clearProperty("SYSTEM_PROCESSING_PASSWORD");
   }
 
   @Test


### PR DESCRIPTION
# [Jira MODDATAIMP-940](https://issues.folio.org/browse/MODDATAIMP-940)

## Orchid counterpart: #301 

## Purpose
Remove the default system user password.  This PR also cleans up a bit of the infrastructure around these API requests, to make them cleaner and more readable/maintainable.

## Approach
Adds logic to ensure splitting is enabled before creating the system user.  Also, the password environment variable is checked to ensure it's set when needed (and will fail tenant install if not).

Additional logic was added to handle cases where the password may change with time, to allow hosting providers to implement rolling passwords/etc.