### PR TITLE
[MODDATAIMP-947] Fix improper system user account management

### DIFF
--- a/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -46,10 +46,14 @@ public class ModTenantAPI extends TenantAPI {
 
   @Override
   Future<Integer> loadData(TenantAttributes attributes, String tenantId, Map<String, String> headers, Context context) {
-    if (fileSplittingEnabled) {
-      systemUserAuthService.initializeSystemUser(headers);
-    }
-    return super.loadData(attributes, tenantId, headers, context)
+    return Future.succeededFuture()
+      .compose(v -> {
+        if (fileSplittingEnabled) {
+          return systemUserAuthService.initializeSystemUser(headers);
+        }
+        return Future.succeededFuture();
+      })
+      .compose(v -> super.loadData(attributes, tenantId, headers, context))
       .compose(num -> {
         initStorageCleanupService(headers, context);
         return setupDefaultFileExtensions(headers).map(num);

--- a/src/main/java/org/folio/service/auth/AuthClient.java
+++ b/src/main/java/org/folio/service/auth/AuthClient.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.logging.log4j.LogManager;
@@ -99,7 +100,10 @@ public class AuthClient extends ApiClient {
   public static class LoginCredentials {
 
     private String username;
+
+    @ToString.Exclude
     private String password;
+
     private String tenant;
   }
 }

--- a/src/main/java/org/folio/service/auth/SystemUserAuthService.java
+++ b/src/main/java/org/folio/service/auth/SystemUserAuthService.java
@@ -157,10 +157,12 @@ public class SystemUserAuthService {
 
     LOGGER.info("Attempting {}", getLoginCredentials(okapiConnectionParams));
 
-    return authClient.login(
-      okapiConnectionParams,
-      getLoginCredentials(okapiConnectionParams)
-    );
+    return authClient
+      .login(okapiConnectionParams, getLoginCredentials(okapiConnectionParams))
+      .onFailure((Throwable err) ->
+        LOGGER.error("Unable to login as system user", err)
+      )
+      .onSuccess((String v) -> LOGGER.info("Logged in successfully!"));
   }
 
   protected User getOrCreateSystemUserFromApi(

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -415,9 +415,9 @@ public abstract class AbstractRestTest {
     );
 
     tenantMockServer.stubFor(
-      post(urlPathEqualTo("/authn/login"))
+      post(urlPathEqualTo("/authn/login-with-expiry"))
         .willReturn(
-          okJson(JsonObject.of("okapiToken", "token").toString())
+          WireMock.created().withHeader("Set-Cookie", "folioAccessToken=result")
         )
     );
 

--- a/src/test/java/org/folio/service/auth/SystemUserAuthServiceTest.java
+++ b/src/test/java/org/folio/service/auth/SystemUserAuthServiceTest.java
@@ -341,9 +341,11 @@ public class SystemUserAuthServiceTest {
     // first attempt: invalid
     // second attempt (after reset): valid
     when(authClient.login(any(), any()))
-      .thenThrow(
-        new NoSuchElementException(
-          "test simulating the credentials were invalid"
+      .thenReturn(
+        Future.failedFuture(
+          new NoSuchElementException(
+            "test simulating the credentials were invalid"
+          )
         )
       )
       .thenReturn(Future.succeededFuture("test token"));


### PR DESCRIPTION
# [Jira MODDATAIMP-947](https://issues.folio.org/browse/MODDATAIMP-947)

## Purpose
With Poppy, certain changes were made to user logins/token management.  We updated the code here to handle this, however, missed a couple spots relating to password setting on tenant install.

## Approach
Ensure proper handling of login results when installing on tenant
