### PR TITLE
[MODDATAIMP-942] [Orchid] Add missing permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -255,7 +255,11 @@
             "acquisitions-units-storage.memberships.collection.get",
             "isbn-utils.convert-to-13.get",
             "instance-authority-links.instances.collection.get",
-            "instance-authority-links.instances.collection.put"
+            "instance-authority-links.instances.collection.put",
+            "user-tenants.collection.get",
+            "organizations.organizations.collection.get",
+            "invoices.acquisitions-units-assignments.assign",
+            "invoices.acquisitions-units-assignments.manage"
           ],
           "permissionsDesired": [
             "invoices.acquisitions-units-assignments.assign",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -257,9 +257,7 @@
             "instance-authority-links.instances.collection.get",
             "instance-authority-links.instances.collection.put",
             "user-tenants.collection.get",
-            "organizations.organizations.collection.get",
-            "invoices.acquisitions-units-assignments.assign",
-            "invoices.acquisitions-units-assignments.manage"
+            "organizations.organizations.collection.get"
           ],
           "permissionsDesired": [
             "invoices.acquisitions-units-assignments.assign",

--- a/src/main/resources/permissions.txt
+++ b/src/main/resources/permissions.txt
@@ -68,8 +68,6 @@ invoice-storage.invoices.item.put
 invoice-storage.invoice-lines.item.post
 invoice-storage.invoice-lines.item.put
 invoice-storage.invoice-lines.collection.get
-acquisitions-units.units.collection.get
-acquisitions-units.memberships.collection.get
 orders.po-lines.item.get
 orders.po-lines.collection.get
 orders-storage.order-invoice-relationships.collection.get
@@ -99,3 +97,7 @@ acquisitions-units-storage.memberships.collection.get
 isbn-utils.convert-to-13.get
 instance-authority-links.instances.collection.get
 instance-authority-links.instances.collection.put
+user-tenants.collection.get
+organizations.organizations.collection.get
+invoices.acquisitions-units-assignments.assign
+invoices.acquisitions-units-assignments.manage


### PR DESCRIPTION
# [Jira MODDATAIMP-942](https://issues.folio.org/browse/MODDATAIMP-942)

Orchid version of #309 

## Purpose
A couple straggling permissions needed to be added for full DI functionality:

- Needed for EDITFACT imports with acquisition units (see FAT-1470)
  - invoices.acquisitions-units-assignments.assign
  - invoices.acquisitions-units-assignments.manage
- Part of mod-entities-links and potentially user creation/update
  - user-tenants.collection.get