### PR TITLE
MODDATAIMP-969: Update folio-s3-client to v2.0.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-10-13 v3.0.0
+* [MODDATAIMP-969](https://issues.folio.org/browse/MODDATAIMP-969) Update folio-s3-client to v2.0.5
 * [MODDATAIMP-871](https://issues.folio.org/browse/MODDATAIMP-871) Upgrade folio-kafka-wrapper to 3.0.0 version
 * [MODDATAIMP-854](https://issues.folio.org/browse/MODDATAIMP-854) Upgrade mod-data-import to Java 17
 * [UXPROD-4337](https://issues.folio.org/browse/UXPROD-4337) Add S3 file upload/download support, file splitting for MARC 21, and smarter job prioritization

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <kafka-junit.version>3.3.0</kafka-junit.version>
     <spring.version>5.3.23</spring.version>
     <apache-httpclient.version>4.5.13</apache-httpclient.version>
-    <folio-s3-client.version>2.0.4</folio-s3-client.version>
+    <folio-s3-client.version>2.0.5</folio-s3-client.version>
     <aws-sdk-java.version>2.19.2</aws-sdk-java.version>
   </properties>
 


### PR DESCRIPTION
## Purpose
Update folio-s3-client to v2.0.5

## Learning
JIRA: https://issues.folio.org/browse/MODDATAIMP-969.
