### PR TITLE
MODDATAIMP-1007: Make endpoint as async.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2023-XX-XX v3.1.0-SNAPSHOT
+* [MODDATAIMP-1007](https://issues.folio.org/browse/MODDATAIMP-1007) Make endpoint as async.
+
 ## 2023-XX-XX v3.1.0
 * [MODDATAIMP-1003](https://folio-org.atlassian.net/browse/MODDATAIMP-1003)
 * [MODDATAIMP-886](https://issues.folio.org/browse/MODDATAIMP-886) Create Kafka topics instead of relying on auto create

--- a/src/main/java/org/folio/rest/impl/DataImportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataImportImpl.java
@@ -286,13 +286,11 @@ public class DataImportImpl implements DataImport {
               entity,
               new ChangeManagerClient(params.getOkapiUrl(), params.getTenantId(), params.getToken(), vertxContext.owner().createHttpClient()),
               params
-            )
-            .onSuccess(v -> 
-              Future.succeededFuture(PostDataImportUploadDefinitionsProcessFilesByUploadDefinitionIdResponse.respond204())
-                .map(Response.class::cast)
-                .onComplete(asyncResultHandler)
-            )
-            .onFailure(err -> asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(err))));
+            );
+          Future.succeededFuture()
+            .map(PostDataImportUploadDefinitionsProcessFilesByUploadDefinitionIdResponse.respond204())
+            .map(Response.class::cast)
+            .onComplete(asyncResultHandler);
         } else {
           fileProcessor.process(
             JsonObject.mapFrom(entity),
@@ -513,7 +511,7 @@ public class DataImportImpl implements DataImport {
   @Override
   public void getDataImportSplitStatus(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
                                        Context vertxContext) {
-    vertxContext.runOnContext(v -> 
+    vertxContext.runOnContext(v ->
       Future.succeededFuture(new SplitStatus().withSplitStatus(this.fileSplittingEnabled))
         .map(GetDataImportSplitStatusResponse::respond200WithApplicationJson)
         .map(Response.class::cast)

--- a/src/main/java/org/folio/service/file/SplitFileProcessingService.java
+++ b/src/main/java/org/folio/service/file/SplitFileProcessingService.java
@@ -55,6 +55,9 @@ import org.folio.service.upload.UploadDefinitionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import static org.folio.rest.jaxrs.model.StatusDto.ErrorStatus.FILE_PROCESSING_ERROR;
+import static org.folio.rest.jaxrs.model.StatusDto.Status.ERROR;
+
 /**
  * Service containing methods to manage the lifecycle and initiate processing of
  * split files.
@@ -136,7 +139,14 @@ public class SplitFileProcessingService {
             )
           )
           .onSuccess(v -> LOGGER.info("Job split and queued successfully!"))
-          .onFailure(err -> LOGGER.error("Unable to start job: ", err))
+          .onFailure(err -> {
+            LOGGER.warn("processFiles:: File was processed with errors by jobExecutionId {}. Cause: {}", entity.getUploadDefinition().getMetaJobExecutionId(), err.getCause());
+            uploadDefinitionService.updateJobExecutionStatus(
+              entity.getUploadDefinition().getMetaJobExecutionId(),
+              new StatusDto().withStatus(ERROR).withErrorStatus(FILE_PROCESSING_ERROR),
+              params);
+            LOGGER.error("Unable to start job: ", err);
+          })
           .<Void>mapEmpty()
           .onComplete(promise),
       false

--- a/src/main/java/org/folio/service/file/SplitFileProcessingService.java
+++ b/src/main/java/org/folio/service/file/SplitFileProcessingService.java
@@ -140,11 +140,14 @@ public class SplitFileProcessingService {
           )
           .onSuccess(v -> LOGGER.info("Job split and queued successfully!"))
           .onFailure(err -> {
-            LOGGER.warn("processFiles:: File was processed with errors by jobExecutionId {}. Cause: {}", entity.getUploadDefinition().getMetaJobExecutionId(), err.getCause());
-            uploadDefinitionService.updateJobExecutionStatus(
-              entity.getUploadDefinition().getMetaJobExecutionId(),
-              new StatusDto().withStatus(ERROR).withErrorStatus(FILE_PROCESSING_ERROR),
-              params);
+            String jobExecutionId = entity.getUploadDefinition().getMetaJobExecutionId();
+            if (jobExecutionId != null) {
+              LOGGER.warn("processFiles:: File was processed with errors by jobExecutionId {}. Cause: {}", jobExecutionId, err.getCause());
+              uploadDefinitionService.updateJobExecutionStatus(
+                jobExecutionId,
+                new StatusDto().withStatus(ERROR).withErrorStatus(FILE_PROCESSING_ERROR),
+                params);
+            }
             LOGGER.error("Unable to start job: ", err);
           })
           .<Void>mapEmpty()

--- a/src/main/java/org/folio/service/file/SplitFileProcessingService.java
+++ b/src/main/java/org/folio/service/file/SplitFileProcessingService.java
@@ -142,7 +142,7 @@ public class SplitFileProcessingService {
           .onFailure(err -> {
             String jobExecutionId = entity.getUploadDefinition().getMetaJobExecutionId();
             if (jobExecutionId != null) {
-              LOGGER.warn("processFiles:: File was processed with errors by jobExecutionId {}. Cause: {}", jobExecutionId, err.getCause());
+              LOGGER.warn("startJob:: File was processed with errors by jobExecutionId {}. Cause: {}", jobExecutionId, err.getCause());
               uploadDefinitionService.updateJobExecutionStatus(
                 jobExecutionId,
                 new StatusDto().withStatus(ERROR).withErrorStatus(FILE_PROCESSING_ERROR),

--- a/src/main/java/org/folio/service/storage/LocalFileStorageService.java
+++ b/src/main/java/org/folio/service/storage/LocalFileStorageService.java
@@ -3,6 +3,7 @@ package org.folio.service.storage;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
@@ -73,7 +74,7 @@ public class LocalFileStorageService extends AbstractFileStorageService {
     Promise<Boolean> promise = Promise.promise();
     try {
       String filePath = fileDefinition.getSourcePath();
-      if (fs.existsBlocking(filePath)) {
+      if (StringUtils.isNotBlank(filePath) && fs.existsBlocking(filePath)) {
         fs.deleteBlocking(filePath);
         promise.complete(true);
       } else {

--- a/src/test/java/org/folio/rest/ProcessS3APITest.java
+++ b/src/test/java/org/folio/rest/ProcessS3APITest.java
@@ -177,7 +177,7 @@ public class ProcessS3APITest extends AbstractRestTest {
   }
 
   @Test
-  public void testProcessingFailure() throws IOException {
+  public void testReturnSuccessEvenIfProcessingFailing() throws IOException {
     RestAssured
       .given()
       .spec(spec)
@@ -197,7 +197,7 @@ public class ProcessS3APITest extends AbstractRestTest {
       .when()
       .post("/data-import/uploadDefinitions/{uploadDefinitionId}/processFiles")
       .then()
-      .statusCode(HttpStatus.SC_NOT_FOUND);
+      .statusCode(HttpStatus.SC_NO_CONTENT);
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/ProcessS3APITest.java
+++ b/src/test/java/org/folio/rest/ProcessS3APITest.java
@@ -1,8 +1,12 @@
 package org.folio.rest;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -177,7 +181,10 @@ public class ProcessS3APITest extends AbstractRestTest {
   }
 
   @Test
-  public void testReturnSuccessEvenIfProcessingFailing() throws IOException {
+  public void testReturnSuccessEvenIfProcessingFailing() {
+    WireMock.stubFor(put(new UrlPathPattern(new RegexPattern("/change-manager/jobExecutions/.*"), true))
+      .willReturn(ok()));
+
     RestAssured
       .given()
       .spec(spec)


### PR DESCRIPTION
## Purpose
The main goal is to make /data-import/uploadDefinitions/{id}/processFiles?defaultMapping=false as async to fix FAT tests.
Also added updating Job status if  it is failed.

## Approach
Complete future, not waiting processing files.
Additional safe check added to another logic.

## Learning
https://folio-org.atlassian.net/browse/MODDATAIMP-1007
