### PR TITLE
MODDATAIMP-1050 Missing interface dependencies in module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,6 +9,10 @@
     {
       "id": "users",
       "version": "15.0 16.0"
+    },
+    {
+      "id": "configuration",
+      "version": "2.0"
     }
   ],
   "provides": [


### PR DESCRIPTION
## Purpose
[MODDATAIMP-1050](https://folio-org.atlassian.net/browse/MODDATAIMP-1050) Missing interface dependencies in module descriptor

## Approach
add configuration interface as required interface
