### PR TITLE
MODDATAIMP-1055: Fix receiving ETag HTTP header value

### DIFF
--- a/scripts/load-marc-data-into-folio-with-split-files-enabled.sh
+++ b/scripts/load-marc-data-into-folio-with-split-files-enabled.sh
@@ -80,7 +80,7 @@ curl --silent --location --request PUT "$UPLOADURL" \
     -D $tmpfile3 \
     --data-binary "@$filename" \
         > $tmpfile4
-ETAG=`grep 'etag' $tmpfile3 | cut -d ':' -f2`
+ETAG=`grep -i 'etag' $tmpfile3 | cut -d ':' -f2`
 echo "ETAG=$ETAG"
 echo
 sleep 10


### PR DESCRIPTION
## Purpose
The bash script for importing files via API does not work.

## Approach
Getting the ETag HTTP header is made case-insensitive.

## Learning
[MODDATAIMP-1055](https://folio-org.atlassian.net/browse/MODDATAIMP-1055)