### PR TITLE
MODDATAIMP-1087: log4j-slf4j2-impl, log4j 2.24.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODDATAIMP-1054](https://folio-org.atlassian.net/browse/MODDATAIMP-1054) Fixing : "File upload already in progress" appears when data import job was run for more than one file.
 * [MODDATAIMP-1082](https://folio-org.atlassian.net/browse/MODDATAIMP-1082) Improve error logging for AWS-related issue.
 * [MODDATAIMP-1085](https://folio-org.atlassian.net/browse/MODDATAIMP-1085) Provide module permissions for subject types and sources 
+* [MODDATAIMP-1087](https://folio-org.atlassian.net/browse/MODDATAIMP-1087) log4j-slf4j2-impl, log4j 2.24.0
 
 ## 2024-03-21 v3.1.0
 * [MODDATAIMP-1020](https://folio-org.atlassian.net/browse/MODDATAIMP-1020) Update load-marc-data-into-folio script with Poppy

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.0</version>
+        <version>2.24.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -217,7 +217,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODDATAIMP-1087

## Purpose
Upgrade from log4j-slf4j-impl to log4j-slf4j2-impl.

Upgrade log4j from 2.17.0 to 2.24.0.

## Approach
Change pom.xml.

#### TODOS and Open Questions
- [x] Check logging.