### PR TITLE
MODSOURMAN-1228: Permission added.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -207,6 +207,7 @@
             "inventory-storage.preceding-succeeding-titles.item.delete",
             "inventory-storage.subject-sources.collection.get",
             "inventory-storage.subject-types.collection.get",
+            "inventory-storage.instance-date-types.collection.get",
             "converter-storage.field-protection-settings.get",
             "converter-storage.jobprofilesnapshots.get",
             "invoice-storage.invoices.item.post",


### PR DESCRIPTION
## Purpose
The main purpose is to update default mapping for Date type, Date 1, and Date 2 fields

## Approach
So there should be extended our default mapper. Previouslym we did NOT map simple JsonObjects, just String or Arrays. In our case, the "Dates" - is an object, and our mapper can't work with this type of Instance's field. So there was added a new property to rules named "createSingleObject". And if mapper find this rules - it will handle this rule via specific logic, building rules into 1 JsonObject. 

1. New Pemission added.
## Learning
JIRA: https://folio-org.atlassian.net/browse/MODSOURMAN-1228

**NOTE**: This PR should be merged **ONLY** with these 2: https://github.com/folio-org/data-import-processing-core/pull/367 AND https://github.com/folio-org/data-import-processing-core/pull/367
