### PR TITLE
MODDATAIMP-1099 mod-data-import Ramsons 2024 R2 - RMB v35.3.x update

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,0 +1,26 @@
+name: postgres
+on:
+  workflow_dispatch:
+    inputs:
+      postgres:
+        description: "List of postgres container images, to be injected as TESTCONTAINERS_POSTGRES_IMAGE"
+        default: '["postgres:16-alpine", "postgres:18-alpine"]'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        postgres: ${{ fromJSON(github.event.inputs.postgres) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+      - run: mvn --batch-mode verify
+        env:
+          TESTCONTAINERS_POSTGRES_IMAGE: ${{ matrix.postgres }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * [MODDATAIMP-1085](https://folio-org.atlassian.net/browse/MODDATAIMP-1085) Provide module permissions for subject types and sources 
 * [MODDATAIMP-1088](https://folio-org.atlassian.net/browse/MODDATAIMP-1088) Upgrade Spring from 5.3.23 to 6.1.13
 * [MODDATAIMP-1087](https://folio-org.atlassian.net/browse/MODDATAIMP-1087) log4j-slf4j2-impl, log4j 2.24.0
+* [MODDATAIMP-1099](https://folio-org.atlassian.net/browse/MODDATAIMP-1099) mod-data-import Ramsons 2024 R2 - RMB v35.3.x update
 
 ## 2024-03-21 v3.1.0
 * [MODDATAIMP-1020](https://folio-org.atlassian.net/browse/MODDATAIMP-1020) Update load-marc-data-into-folio script with Poppy

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>35.2.0</raml-module-builder.version>
-    <vertx.version>4.5.4</vertx.version>
+    <raml-module-builder.version>35.3.0</raml-module-builder.version>
+    <vertx.version>4.5.7</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <marc4j.version>2.9.2</marc4j.version>


### PR DESCRIPTION
## Purpose
[MODDATAIMP-1099](https://folio-org.atlassian.net/browse/MODDATAIMP-1099) mod-data-import Ramsons 2024 R2 - RMB v35.3.x update

## Approach
Upgrade to RMB v35.3

Follow the [RMB upgrade notes for 35.3.x](https://github.com/folio-org/raml-module-builder/releases/tag/v35.3.0) upgrade.

Upgrade Vertx to 4.5.7 version.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
