### PR TITLE
MODDATAIMP-1100 Add missing permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -150,6 +150,7 @@
             "change-manager.jobExecutions.item.get",
             "change-manager.jobExecutions.children.collection.get",
             "change-manager.jobexecutions.post",
+            "change-manager.jobExecutions.status.item.put",
             "change-manager.jobExecutions.jobProfile.item.put",
             "mapping-metadata.item.get",
             "source-storage.records.collection.get",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -83,7 +83,7 @@
           "modulePermissions": [
             "change-manager.jobExecutions.item.get",
             "change-manager.jobExecutions.children.collection.get",
-            "change-manager.jobExecutions.jobProfile.item.put"
+            "change-manager.jobExecutions.item.put"
           ]
         },
         {
@@ -97,7 +97,7 @@
           "modulePermissions": [
             "configuration.entries.collection.get",
             "change-manager.jobexecutions.post",
-            "change-manager.jobExecutions.jobProfile.item.put"
+            "change-manager.jobExecutions.item.put"
           ]
         },
         {
@@ -122,7 +122,7 @@
             "data-import.assembleStorageFile.post"
           ],
           "modulePermissions": [
-            "change-manager.jobExecutions.jobProfile.item.put"
+            "change-manager.jobExecutions.item.put"
           ]
         },
         {
@@ -135,7 +135,7 @@
           ],
           "modulePermissions": [
             "configuration.entries.collection.get",
-            "change-manager.jobExecutions.jobProfile.item.put"
+            "change-manager.jobExecutions.item.put"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -83,7 +83,7 @@
           "modulePermissions": [
             "change-manager.jobExecutions.item.get",
             "change-manager.jobExecutions.children.collection.get",
-            "change-manager.jobexecutions.put"
+            "change-manager.jobExecutions.jobProfile.item.put"
           ]
         },
         {
@@ -97,7 +97,7 @@
           "modulePermissions": [
             "configuration.entries.collection.get",
             "change-manager.jobexecutions.post",
-            "change-manager.jobexecutions.put"
+            "change-manager.jobExecutions.jobProfile.item.put"
           ]
         },
         {
@@ -122,7 +122,7 @@
             "data-import.assembleStorageFile.post"
           ],
           "modulePermissions": [
-            "change-manager.jobexecutions.put"
+            "change-manager.jobExecutions.jobProfile.item.put"
           ]
         },
         {
@@ -135,7 +135,7 @@
           ],
           "modulePermissions": [
             "configuration.entries.collection.get",
-            "change-manager.jobexecutions.put"
+            "change-manager.jobExecutions.jobProfile.item.put"
           ]
         },
         {
@@ -147,9 +147,10 @@
             "data-import.uploadDefinitions.processFiles.item.post"
           ],
           "modulePermissions": [
-            "change-manager.jobexecutions.get",
+            "change-manager.jobExecutions.item.get",
+            "change-manager.jobExecutions.children.collection.get",
             "change-manager.jobexecutions.post",
-            "change-manager.jobexecutions.put",
+            "change-manager.jobExecutions.jobProfile.item.put",
             "mapping-metadata.item.get",
             "source-storage.records.collection.get",
             "source-storage.records.item.get",


### PR DESCRIPTION
[MODDATAIMP-1100](https://folio-org.atlassian.net/browse/MODDATAIMP-1100)

## Purpose
Data-import karate tests falls into infinity loop, breaking CI Quality Gates pipeline

## Approach
Add missing permissions

## Learning
Old permission | New permissions
-- | --
data-import.uploaddefinitions.get | data-import.uploadDefinitions.item.get, data-import.uploadDefinitions.collection.get
data-import.uploaddefinitions.files.post | data-import.uploadDefinitions.files.item.post, data-import.uploadDefinitions.processFiles.item.post
data-import.fileExtensions.get | data-import.fileExtensions.item.get, data-import.fileExtensions.collection.get
data-import.fileExtensions.default | data-import.fileExtensions.default.post
data-import.uploadUrl.get | data-import.uploadUrl.item.get, data-import.uploadUrl.subsequent.item.get
converter-storage.jobprofile.get | converter-storage.jobprofile.item.get, converter-storage.jobprofile.collection.get
converter-storage.matchprofile.get | converter-storage.matchprofile.item.get, converter-storage.matchprofile.collection.get
converter-storage.actionprofile.get | converter-storage.action-profile.item.get, converter-storage.action-profile.collection.get
converter-storage.mappingprofile.get | converter-storage.mapping-profile.item.get, converter-storage.mapping-profile.collection.get
converter-storage.profileassociation.get | converter-storage.profile-association.item.get, converter-storage.profile-association.collection.get, converter-storage.profile-associations.details.item.get, converter-storage.profile-associations.masters.item.get
converter-storage.forms-configs.get | converter-storage.forms-configs.item.get, converter-storage.forms-configs.collection.get
converter-storage.field-protection-settings.get | converter-storage.field-protection-settings.item.get, converter-storage.field-protection-settings.collection.get
metadata-provider.jobexecutions.get | metadata-provider.jobExecutions.collection.get, metadata-provider.jobExecutions.users.collection.get, metadata-provider.jobExecutions.jobProfiles.collection.get
metadata-provider.logs.get | metadata-provider.jobLogEntries.collection.get, metadata-provider.jobLogEntries.records.item.get, metadata-provider.journalRecords.collection.get, metadata-provider.jobSummary.item.get
change-manager.jobexecutions.put | change-manager.jobExecutions.item.put, change-manager.jobExecutions.status.item.put, change-manager.jobExecutions.jobProfile.item.put
change-manager.jobexecutions.get | change-manager.jobExecutions.item.get, change-manager.jobExecutions.children.collection.get
mapping-metadata.get | mapping-metadata.item.get, mapping-metadata.type.item.get
source-storage.populate.records | source-storage.records.populate.collection.post
source-storage.snapshots.get | source-storage.snapshots.item.get, source-storage.snapshots.collection.get
source-storage.records.fetch | source-storage.parsed-records.fetch.collection.post
source-storage.sourceRecords.get | source-storage.stream.source-records.collection.get, source-storage.source-records.item.get, source-storage.source-records.collection.get
source-storage.records.get | source-storage.stream.marc-record-identifiers.collection.post, source-storage.records.collection.get, source-storage.records.item.get, source-storage.records.formatted.item.get, source-storage.stream.records.collection.get, source-storage.records.matching.collection.post
source-storage.migrations.get | source-storage.migrations.item.get

<p></p>
