### PR TITLE
MODDATAIMP-1121 Remove X-OKAPI-TOKEN header from Kafka messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2024-xx-xx v3.3.0-SNAPSHOT
 * [MODDATAIMP-1109](https://folio-org.atlassian.net/browse/MODDATAIMP-1109) Issue with mod-data-import module when configuration for AWS is set
+* [MODDATAIMP-1121](https://folio-org.atlassian.net/browse/MODDATAIMP-1121) Remove token header for Eureka env 
 
 ## 2024-10-29 v3.2.0
 * [MODDATAIMP-1054](https://folio-org.atlassian.net/browse/MODDATAIMP-1054) Add error handling for script interrupts

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-utils</artifactId>
-      <version>1.13.0</version>
+      <version>1.14.0-SNAPSHOT</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/service/file/S3JobRunningVerticle.java
+++ b/src/main/java/org/folio/service/file/S3JobRunningVerticle.java
@@ -272,7 +272,7 @@ public class S3JobRunningVerticle extends AbstractVerticle {
   protected OkapiConnectionParams getConnectionParams(
     DataImportQueueItem queueItem
   ) {
-    return new OkapiConnectionParams(
+    return OkapiConnectionParams.createSystemUserConnectionParams(
       Map.of(
         XOkapiHeaders.URL.toLowerCase(),
         queueItem.getOkapiUrl(),
@@ -294,7 +294,7 @@ public class S3JobRunningVerticle extends AbstractVerticle {
     DataImportQueueItem queueItem,
     String userId
   ) {
-    return new OkapiConnectionParams(
+    return OkapiConnectionParams.createSystemUserConnectionParams(
       Map.of(
         XOkapiHeaders.URL.toLowerCase(),
         queueItem.getOkapiUrl(),

--- a/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
+++ b/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
@@ -79,7 +79,7 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
       ProcessFilesRqDto request = jsonRequest.mapTo(ProcessFilesRqDto.class);
       UploadDefinition uploadDefinition = request.getUploadDefinition();
       JobProfileInfo jobProfile = request.getJobProfileInfo();
-      OkapiConnectionParams params = new OkapiConnectionParams(jsonParams.mapTo(HashMap.class), this.vertx);
+      OkapiConnectionParams params = OkapiConnectionParams.createSystemUserConnectionParams(jsonParams.mapTo(HashMap.class), this.vertx);
       UploadDefinitionService uploadDefinitionService = new UploadDefinitionServiceImpl(vertx);
       succeededFuture()
         .compose(ar -> uploadDefinitionService.getJobExecutions(uploadDefinition, params))


### PR DESCRIPTION
## Purpose
Remove X-OKAPI-TOKEN header from Kafka messages 

## Learning
[MODDATAIMP-1121](https://folio-org.atlassian.net/browse/MODDATAIMP-1121)
