### PR TITLE
Upgrade localstack test container from 0.11.3 to s3-latest

### DIFF
--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -157,7 +157,7 @@ public abstract class AbstractRestTest {
 
   @Container
   private static final LocalStackContainer localStackContainer = new LocalStackContainer(
-    DockerImageName.parse("localstack/localstack:0.11.3")
+    DockerImageName.parse("localstack/localstack:s3-latest")
   )
     .withServices(LocalStackContainer.Service.S3);
 


### PR DESCRIPTION
## Purpose
The localstack test container 0.11.3 has been released June 2020.
It is outdated. It is large.

## Approach
Upgrade to s3-latest that is current and much smaller: https://hub.docker.com/r/localstack/localstack/tags

#### TODOS and Open Questions
- [x] Check logging.