### PR TITLE
MODDATAIMP-1190: Netty 4.1.118 (Vert.x 4.5.14, AWS S3 2.31.21) fix vuln

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <raml-module-builder.version>35.4.0</raml-module-builder.version>
-    <vertx.version>4.5.7</vertx.version>
+    <vertx.version>4.5.14</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <marc4j.version>2.9.2</marc4j.version>
@@ -30,7 +30,7 @@
     <spring.version>6.1.13</spring.version>
     <apache-httpclient.version>4.5.13</apache-httpclient.version>
     <folio-s3-client.version>2.3.0</folio-s3-client.version>
-    <aws-sdk-java.version>2.29.6</aws-sdk-java.version>
+    <aws-sdk-java.version>2.31.21</aws-sdk-java.version>
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
     <testcontainers.version>1.20.4</testcontainers.version>
   </properties>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODDATAIMP-1190

## Purpose
Fix this security vulnerability in Netty:
* CVE-2025-24970 https://github.com/netty/netty/security/advisories/GHSA-4g8c-wm8x-jfhw – netty-handler SslHandler/SSLEngine native crash

## Approach
Upgrade Vertx from 4.5.7 to 4.5.14.

Upgrade AWS S3 client from 2.29.6 to 2.31.21.

These two upgrades indirectly upgrade Netty from 4.1.108.Final to 4.1.118.Final fixing the security vulnerability:

Update UploadDefinitionAPITest to
* fix any race condition
* remove useless Async
* fix postFilesProcessingWithUnprocessableEntity() and remove its `@Ignore`

#### TODOS and Open Questions
- [x] Check logging.