### PR TITLE
MODORDERS-1269. Remove unnecessary permissions after deleting alerts and reporting codes

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -241,8 +241,6 @@
             "orders-storage.po-line-number.get",
             "orders-storage.po-lines.collection.get",
             "orders-storage.po-lines.item.post",
-            "orders-storage.alerts.item.post",
-            "orders-storage.reporting-codes.item.post",
             "orders-storage.configuration.prefixes.collection.get",
             "orders-storage.configuration.suffixes.collection.get",
             "configuration.entries.collection.get",


### PR DESCRIPTION
## Purpose
[MODORDERS-1269](https://folio-org.atlassian.net/browse/MODORDERS-1269) - Remove alerts and reporting codes from order lines, use a single order line schema

## Approach
Use a single po line schema, no more "composite po line", remove unused permissions

#### Related PRs
See https://github.com/folio-org/mod-orders-storage/pull/477
Required for compilation: https://github.com/folio-org/acq-models/pull/520
