### PR TITLE
MODDATAIMP-1214 - Add permission to permit update of shared instance and MARC

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2025-mm-dd v3.4.0-SNAPSHOT
+* [MODDATAIMP-1214](https://folio-org.atlassian.net/browse/MODDATAIMP-1214) Add permission to permit update of shared instance and MARC
+
 ## 2024-03-13 v3.3.0
 * [MODDATAIMP-1109](https://folio-org.atlassian.net/browse/MODDATAIMP-1109) Issue with mod-data-import module when configuration for AWS is set
 * [MODDATAIMP-1121](https://folio-org.atlassian.net/browse/MODDATAIMP-1121) Remove token header for Eureka env

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 2025-mm-dd v3.4.0-SNAPSHOT
-* [MODDATAIMP-1214](https://folio-org.atlassian.net/browse/MODDATAIMP-1214) Add permission to permit update of shared instance and MARC
+* [MODDATAIMP-1214](https://folio-org.atlassian.net/browse/MODDATAIMP-1214) Ensure permission that allows update of shared instance and MARC
 
 ## 2024-03-13 v3.3.0
 * [MODDATAIMP-1109](https://folio-org.atlassian.net/browse/MODDATAIMP-1109) Issue with mod-data-import module when configuration for AWS is set

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -262,7 +262,7 @@
             "orders-storage.acquisition-methods.collection.get"
           ],
           "permissionsDesired": [
-            "data-import.central-record.item.put",
+            "consortia.data-import.central-record-update.execute",
             "invoices.acquisitions-units-assignments.assign",
             "orders.acquisitions-units-assignments.assign",
             "orders.acquisitions-units-assignments.manage",
@@ -478,11 +478,6 @@
       "permissionName": "data-import.jobexecution.cancel",
       "displayName": "Data Import - cancel running job",
       "description": "Cancel running job"
-    },
-    {
-      "permissionName": "data-import.central-record.item.put",
-      "displayName": "Data Import - update shared record",
-      "description": "Update shared instance and MARC record"
     },
     {
       "permissionName": "data-import.upload.all",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -479,6 +479,11 @@
       "description": "Cancel running job"
     },
     {
+      "permissionName": "data-import.central-record.item.put",
+      "displayName": "Data Import - update shared record",
+      "description": "Update shared instance and MARC record"
+    },
+    {
       "permissionName": "data-import.upload.all",
       "displayName": "Data Import File Upload - all permissions",
       "description": "Entire set of permissions needed to use file uploads",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -262,6 +262,7 @@
             "orders-storage.acquisition-methods.collection.get"
           ],
           "permissionsDesired": [
+            "data-import.central-record.item.put",
             "invoices.acquisitions-units-assignments.assign",
             "orders.acquisitions-units-assignments.assign",
             "orders.acquisitions-units-assignments.manage",


### PR DESCRIPTION
## Purpose
to restrict shared instance/record update through data import

## Approach
* add permission that will allow update of shared instance/record through data import


## Learning
[MODDATAIMP-1214](https://issues.folio.org/browse/MODDATAIMP-1214)
