### PR TITLE
MODDATAIMP-1223 - File splitting (DI) creating duplicate records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2025-mm-dd v3.4.0-SNAPSHOT
 * [MODDATAIMP-1214](https://folio-org.atlassian.net/browse/MODDATAIMP-1214) Ensure permission that allows update of shared instance and MARC
 * [MODSOURMAN-1136](https://folio-org.atlassian.net/browse/MODSOURMAN-1136) Use dedicated job cancellation endpoint instead for job status update
+* [MODDATAIMP-1223](https://folio-org.atlassian.net/browse/MODDATAIMP-1223) File splitting creates duplicate records
 
 ## 2024-03-13 v3.3.0
 * [MODDATAIMP-1109](https://folio-org.atlassian.net/browse/MODDATAIMP-1109) Issue with mod-data-import module when configuration for AWS is set

--- a/src/main/java/org/folio/dao/DataImportQueueItemDao.java
+++ b/src/main/java/org/folio/dao/DataImportQueueItemDao.java
@@ -17,15 +17,17 @@ public interface DataImportQueueItemDao {
   Future<DataImportQueueItemCollection> getAllQueueItems();
 
   /**
-   * Get all {@link DataImportQueueItem} in database where processing=false
+   * Get all {@link DataImportQueueItem} in database where processing=false using the specified {@code connection}
    *
+   * @param connection database connection
    * @return future with {@link DataImportQueueItemCollection}
    */
   Future<DataImportQueueItemCollection> getAllWaitingQueueItems(PgConnection connection);
 
   /**
-   * Get all {@link DataImportQueueItem} in database where processing=true
+   * Get all {@link DataImportQueueItem} in database where processing=true using the specified {@code connection}
    *
+   * @param connection database connection
    * @return future with {@link DataImportQueueItemCollection}
    */
   Future<DataImportQueueItemCollection> getAllInProgressQueueItems(PgConnection connection);
@@ -34,7 +36,7 @@ public interface DataImportQueueItemDao {
    * Get all in progress and waiting queue items, send them through the
    * {@code processor}, and mark the processor's output as
    * {@code processing=true}.
-   *
+   * <p>
    * This is done as <strong>one atomic operation</strong>, ensuring that no
    * other worker can process the same queue item.
    *
@@ -59,20 +61,20 @@ public interface DataImportQueueItemDao {
   /**
    * Saves {@link DataImportQueueItem} to database
    *
-   * @param DataImportQueueItem DataImportQueueItem to save
+   * @param dataImportQueueItem DataImportQueueItem to save
    * @return future with added row's ID
    */
   Future<String> addQueueItem(DataImportQueueItem dataImportQueueItem);
 
   /**
-   * Updates {@link DataImportQueueItem} in database
+   * Updates {@link DataImportQueueItem} in database using the specified {@code connection}
    *
-   * @param fileExtension FileExtension to update
-   * @param conn
+   * @param connection          database connection
+   * @param dataImportQueueItem DataImportQueueItem to update
    * @return future with {@link DataImportQueueItem}
    */
   Future<DataImportQueueItem> updateQueueItem(
-    PgConnection conn, DataImportQueueItem dataImportQueueItem
+    PgConnection connection, DataImportQueueItem dataImportQueueItem
   );
 
   /**
@@ -86,8 +88,8 @@ public interface DataImportQueueItemDao {
   /**
    * Deletes all {@link DataImportQueueItem}s from database with the provided job execution ID.
    *
-   * @param id DataImportQueueItem id
+   * @param jobExecutionId JobExecution id
    * @return future that resolves with the number of deleted rows, failing if none were deleted
    */
-  Future<Integer> deleteQueueItemsByJobExecutionId(String jobExecution);
+  Future<Integer> deleteQueueItemsByJobExecutionId(String jobExecutionId);
 }

--- a/src/main/java/org/folio/dao/DataImportQueueItemDao.java
+++ b/src/main/java/org/folio/dao/DataImportQueueItemDao.java
@@ -3,6 +3,8 @@ package org.folio.dao;
 import io.vertx.core.Future;
 import java.util.Optional;
 import java.util.function.BiFunction;
+
+import io.vertx.pgclient.PgConnection;
 import org.folio.rest.jaxrs.model.DataImportQueueItem;
 import org.folio.rest.jaxrs.model.DataImportQueueItemCollection;
 
@@ -19,14 +21,14 @@ public interface DataImportQueueItemDao {
    *
    * @return future with {@link DataImportQueueItemCollection}
    */
-  Future<DataImportQueueItemCollection> getAllWaitingQueueItems();
+  Future<DataImportQueueItemCollection> getAllWaitingQueueItems(PgConnection connection);
 
   /**
    * Get all {@link DataImportQueueItem} in database where processing=true
    *
    * @return future with {@link DataImportQueueItemCollection}
    */
-  Future<DataImportQueueItemCollection> getAllInProgressQueueItems();
+  Future<DataImportQueueItemCollection> getAllInProgressQueueItems(PgConnection connection);
 
   /**
    * Get all in progress and waiting queue items, send them through the
@@ -66,10 +68,11 @@ public interface DataImportQueueItemDao {
    * Updates {@link DataImportQueueItem} in database
    *
    * @param fileExtension FileExtension to update
+   * @param conn
    * @return future with {@link DataImportQueueItem}
    */
   Future<DataImportQueueItem> updateQueueItem(
-    DataImportQueueItem dataImportQueueItem
+    PgConnection conn, DataImportQueueItem dataImportQueueItem
   );
 
   /**

--- a/src/main/java/org/folio/dao/DataImportQueueItemDaoImpl.java
+++ b/src/main/java/org/folio/dao/DataImportQueueItemDaoImpl.java
@@ -120,9 +120,9 @@ public class DataImportQueueItemDaoImpl implements DataImportQueueItemDao {
     BiFunction<DataImportQueueItemCollection, DataImportQueueItemCollection, Optional<DataImportQueueItem>> processor
   ) {
     return pgClientFactory.getInstance()
-      .withTransaction((PgConnection connection) -> {
+      .withTransaction((PgConnection connection) ->
         // lock the table to ensure no other workers can read or update
-        return connection.query(format(LOCK_ACCESS_EXCLUSIVE_SQL, MODULE_GLOBAL_SCHEMA, QUEUE_ITEM_TABLE))
+        connection.query(format(LOCK_ACCESS_EXCLUSIVE_SQL, MODULE_GLOBAL_SCHEMA, QUEUE_ITEM_TABLE))
           .execute()
           .compose(v -> Future.all(getAllInProgressQueueItems(connection), getAllWaitingQueueItems(connection)))
           .map((CompositeFuture compositeFuture) -> {
@@ -136,8 +136,8 @@ public class DataImportQueueItemDaoImpl implements DataImportQueueItemDao {
                 .map(Optional::of);
             }
             return Future.succeededFuture(result);
-          });
-      });
+          })
+      );
   }
 
   @Override

--- a/src/main/java/org/folio/dao/DataImportQueueItemDaoImpl.java
+++ b/src/main/java/org/folio/dao/DataImportQueueItemDaoImpl.java
@@ -231,7 +231,8 @@ public class DataImportQueueItemDaoImpl implements DataImportQueueItemDao {
         dataImportQueueItem.getOkapiPermissions()
       );
 
-      return connection.preparedQuery(format(UPDATE_BY_ID_SQL, MODULE_GLOBAL_SCHEMA, QUEUE_ITEM_TABLE))
+      return connection
+        .preparedQuery(format(UPDATE_BY_ID_SQL, MODULE_GLOBAL_SCHEMA, QUEUE_ITEM_TABLE))
         .execute(params)
         .map((RowSet<Row> updateResult) -> {
           if (updateResult.rowCount() == 1) {

--- a/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
+++ b/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
@@ -176,7 +176,7 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
       params, 100, topicName);
     readStreamWrapper.pause();
 
-    LOGGER.debug("processFile:: Starting to send event to Kafka... jobProfile: {}, eventType: {}", jobProfile, eventType);
+    LOGGER.debug("processFile:: Starting to send event to Kafka... jobExecutionId: {}, eventType: {}", jobExecutionId, eventType);
 
     KafkaProducer<String, String> producer = new SimpleKafkaProducerManager(vertx, kafkaConfig).createShared(eventType);
     readStreamWrapper.pipeTo(new WriteStreamWrapper(producer))
@@ -185,9 +185,11 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
       .eventually(x -> producer.close())
       .onComplete(res -> {
         if (res.succeeded()) {
-          LOGGER.info("processFile:: Sending event to Kafka finished. jobProfile: {}, eventType: {}", jobProfile, eventType);
+          LOGGER.info("processFile:: Sending event to Kafka finished. jobExecutionId: {}, eventType: {}",
+            jobExecutionId, eventType);
         } else {
-          LOGGER.warn("processFile:: Error sending event to Kafka. jobProfile: {}, eventType: {}", jobProfile, eventType, res.cause());
+          LOGGER.warn("processFile:: Error sending event to Kafka. jobExecutionId: {}, eventType: {}",
+            jobExecutionId, eventType, res.cause());
         }
         processFilePromise.handle(res);
       });

--- a/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
+++ b/src/main/java/org/folio/service/processing/ParallelFileChunkingProcessor.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.jaxrs.model.StatusDto.ErrorStatus.FILE_PROCESSING_ERROR;
@@ -134,7 +135,6 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
    * @param file               file on disk
    * @param jobExecutionId     job execution ID
    * @param jobProfile         job profile, contains profile type
-   * @param fileStorageService service to obtain file
    * @param params             parameters necessary for connection to the OKAPI
    * @return Future
    */
@@ -181,8 +181,8 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
     KafkaProducer<String, String> producer = new SimpleKafkaProducerManager(vertx, kafkaConfig).createShared(eventType);
     readStreamWrapper.pipeTo(new WriteStreamWrapper(producer))
       .<Void>mapEmpty()
-      .eventually(x -> producer.flush())
-      .eventually(x -> producer.close())
+      .eventually((Supplier<Future<Void>>) producer::flush)
+      .eventually((Supplier<Future<Void>>) producer::close)
       .onComplete(res -> {
         if (res.succeeded()) {
           LOGGER.info("processFile:: Sending event to Kafka finished. jobExecutionId: {}, eventType: {}",
@@ -236,7 +236,7 @@ public class ParallelFileChunkingProcessor implements FileProcessor {
       if (updatedJobsProfileAr.failed()) {
         promise.fail(updatedJobsProfileAr.cause());
       } else {
-        LOGGER.info("updateJobsProfile:: All the child jobs have been updated by job profile, parent job {}", jobs.get(0).getParentJobId());
+        LOGGER.info("updateJobsProfile:: All the child jobs have been updated by job profile, parent job {}", jobs.getFirst().getParentJobId());
         promise.complete();
       }
     });

--- a/src/test/java/org/folio/dao/DataImportQueueDaoTest.java
+++ b/src/test/java/org/folio/dao/DataImportQueueDaoTest.java
@@ -29,7 +29,6 @@ import org.folio.rest.AbstractRestTest;
 import org.folio.rest.jaxrs.model.DataImportQueueItem;
 import org.folio.rest.jaxrs.model.DataImportQueueItemCollection;
 import org.folio.rest.persist.PostgresClient;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/org/folio/dao/DataImportQueueDaoTest.java
+++ b/src/test/java/org/folio/dao/DataImportQueueDaoTest.java
@@ -42,7 +42,6 @@ public class DataImportQueueDaoTest extends AbstractRestTest {
   private DataImportQueueItem IN_PROGRESS_1;
   private DataImportQueueItem IN_PROGRESS_2;
 
-  private PostgresClientFactory pgClientFactory;
   private DataImportQueueItemDao queueItemDao;
 
   @Before
@@ -117,9 +116,8 @@ public class DataImportQueueDaoTest extends AbstractRestTest {
         .withOkapiUrl("okapi-url-p-2")
         .withDataType("data-type-p-2");
 
-    this.pgClientFactory = new PostgresClientFactory(vertx);
     queueItemDao =
-      new DataImportQueueItemDaoImpl(pgClientFactory);
+      new DataImportQueueItemDaoImpl(new PostgresClientFactory(vertx));
   }
 
   @Test

--- a/src/test/java/org/folio/dao/DataImportQueueDaoTest.java
+++ b/src/test/java/org/folio/dao/DataImportQueueDaoTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -136,7 +135,7 @@ public class DataImportQueueDaoTest extends AbstractRestTest {
 
   @Test
   public void testGetAllQueueItems(TestContext context) {
-    CompositeFuture
+    Future
       .all(
         queueItemDao.addQueueItem(WAITING_1),
         queueItemDao.addQueueItem(WAITING_2),
@@ -191,7 +190,7 @@ public class DataImportQueueDaoTest extends AbstractRestTest {
 
   @Test
   public void testAtomicUpdateWithNoChange(TestContext context) {
-    CompositeFuture
+    Future
       .all(
         queueItemDao.addQueueItem(WAITING_1),
         queueItemDao.addQueueItem(WAITING_2),
@@ -243,7 +242,7 @@ public class DataImportQueueDaoTest extends AbstractRestTest {
 
   @Test
   public void testAtomicUpdateWithChange(TestContext context) {
-    CompositeFuture
+    Future
       .all(
         queueItemDao.addQueueItem(WAITING_1),
         queueItemDao.addQueueItem(WAITING_2),
@@ -326,7 +325,7 @@ public class DataImportQueueDaoTest extends AbstractRestTest {
 
   @Test
   public void testGetById(TestContext context) {
-    CompositeFuture
+    Future
       .all(
         queueItemDao.addQueueItem(WAITING_1),
         queueItemDao.addQueueItem(IN_PROGRESS_1)
@@ -374,7 +373,7 @@ public class DataImportQueueDaoTest extends AbstractRestTest {
 
   @Test
   public void testDeleteById(TestContext context) {
-    CompositeFuture
+    Future
       .all(
         queueItemDao.addQueueItem(WAITING_1),
         queueItemDao.addQueueItem(WAITING_2)
@@ -414,7 +413,7 @@ public class DataImportQueueDaoTest extends AbstractRestTest {
 
   @Test
   public void testDeleteByJobExecutionId(TestContext context) {
-    CompositeFuture
+    Future
       .all(
         queueItemDao.addQueueItem(WAITING_1),
         queueItemDao.addQueueItem(WAITING_2),


### PR DESCRIPTION
## Purpose
to fix "file contains duplicates" error that occurs when importing large files


## Approach
* fix lock acquisition and transactional operations to ensure that imported file is processed by one worker
* update tests


## Learning
[MODDATAIMP-1223](https://issues.folio.org/browse/MODDATAIMP-1223)