### PR TITLE
MODDATAIMP-1271 Add S3_SUB_PATH env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@ The worker count is useful for production/multi-tenant environments, where you m
 This module uses S3-compatible storage as part of the file upload process. The following environment variables must be set with values for your S3-compatible storage (AWS S3, Minio Server):
 
 | Name                   | Type              | Required           | Default                  | Description                                                                   |
-|------------------------| ----------------- | ------------------ | ------------------------ | ----------------------------------------------------------------------------- |
+|------------------------|-------------------|--------------------|--------------------------|-------------------------------------------------------------------------------|
 | `S3_URL`               | URL as string     | yes                | `http://127.0.0.1:9000/` | URL of S3-compatible storage                                                  |
 | `S3_REGION`            | string            | yes                | _none_                   | S3 region                                                                     |
 | `S3_BUCKET`            | string            | yes                | _none_                   | Bucket to store and retrieve data                                             |
 | `S3_ACCESS_KEY_ID`     | string            | yes                | _none_                   | S3 access key                                                                 |
 | `S3_SECRET_ACCESS_KEY` | string            | yes                | _none_                   | S3 secret key                                                                 |
 | `S3_IS_AWS`            | `true` or `false` | no, if using MinIO | `false`                  | If AWS S3 is being used (`true` if so, `false` other platforms such as MinIO) |
-
+| `S3_SUB_PATH`          | string            | yes                | mod-data-import          | S3 subpath for file storage                                                   |
 Path-style vs virtual-hosted style requests are described [on the AWS S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access).
 
 > [!WARNING]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -536,6 +536,7 @@
       { "name": "S3_ACCESS_KEY_ID", "value": "AKIAIOSFODNN7EXAMPLE" },
       { "name": "S3_SECRET_ACCESS_KEY", "value": "wJalrXUtnFEMI/K7MDENG/EXAMPLEKEY" },
       { "name": "S3_IS_AWS", "value": "false" },
+      { "name": "S3_SUB_PATH", "value": "mod-data-import"},
       { "name": "SPLIT_FILES_ENABLED", "value": "false" },
       { "name": "RECORDS_PER_SPLIT_FILE", "value": "1000" },
       { "name": "SCORE_JOB_SMALLEST", "value": "40" },

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <lombok.version>1.18.30</lombok.version>
     <spring.version>6.1.13</spring.version>
     <apache-httpclient.version>4.5.13</apache-httpclient.version>
-    <folio-s3-client.version>2.3.0</folio-s3-client.version>
+    <folio-s3-client.version>3.0.0-SNAPSHOT</folio-s3-client.version>
     <aws-sdk-java.version>2.31.21</aws-sdk-java.version>
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
     <testcontainers.version>1.20.6</testcontainers.version>

--- a/src/main/java/org/folio/service/s3storage/FolioS3ClientFactory.java
+++ b/src/main/java/org/folio/service/s3storage/FolioS3ClientFactory.java
@@ -30,6 +30,9 @@ public class FolioS3ClientFactory {
   @Value("#{ T(Boolean).parseBoolean('${minio.forcePathStyle}')}")
   private boolean forcePathStyle;
 
+  @Value("${minio.subPath}")
+  private String subPath;
+
   private FolioS3Client folioS3Client;
 
   public FolioS3ClientFactory() {
@@ -55,6 +58,7 @@ public class FolioS3ClientFactory {
         .awsSdk(awsSdk)
         .forcePathStyle(forcePathStyle)
         .region(region)
+        .subPath(subPath)
         .build()
     );
   }

--- a/src/main/resources/minio.properties
+++ b/src/main/resources/minio.properties
@@ -4,3 +4,4 @@ minio.bucket = ${S3_BUCKET:}
 minio.accessKey = ${S3_ACCESS_KEY_ID:}
 minio.secretKey = ${S3_SECRET_ACCESS_KEY:}
 minio.awsSdk = ${S3_IS_AWS:}
+minio.subPath = ${S3_SUB_PATH:mod-data-import}

--- a/src/test/java/org/folio/rest/AbstractRestTest.java
+++ b/src/test/java/org/folio/rest/AbstractRestTest.java
@@ -87,6 +87,7 @@ public abstract class AbstractRestTest {
   private static final int PORT = NetworkUtils.nextFreePort();
   protected static final String OKAPI_URL = "http://localhost:" + PORT;
   protected static final String MINIO_BUCKET = "test-bucket";
+  protected static final String SUB_PATH = "mod-data-import";
 
   private static final String GET_USER_URL = "/users?query=id==";
 
@@ -167,6 +168,7 @@ public abstract class AbstractRestTest {
     System.setProperty("minio.secretKey", localStackContainer.getSecretKey());
     System.setProperty("minio.bucket", MINIO_BUCKET);
     System.setProperty("minio.awsSdk", "false");
+    System.setProperty("minio.subpath", SUB_PATH);
 
     s3Client = S3ClientFactory.getS3Client(
       S3ClientProperties
@@ -177,6 +179,7 @@ public abstract class AbstractRestTest {
         .bucket(MINIO_BUCKET)
         .awsSdk(false)
         .region(localStackContainer.getRegion())
+        .subPath(SUB_PATH)
         .build()
     );
     s3Client.createBucketIfNotExists();

--- a/src/test/java/org/folio/rest/UploadUrlAPITest.java
+++ b/src/test/java/org/folio/rest/UploadUrlAPITest.java
@@ -33,7 +33,7 @@ public class UploadUrlAPITest extends AbstractRestTest {
       .body(
         "url",
         allOf(
-          matchesRegex(".*/test-bucket/data-import/diku/\\d+-test-name.*"),
+          matchesRegex(".*/test-bucket/mod-data-import/data-import/diku/\\d+-test-name.*"),
           containsString("partNumber=1")
         )
       )
@@ -56,7 +56,7 @@ public class UploadUrlAPITest extends AbstractRestTest {
       .body(
         "url",
         allOf(
-          containsString("/test-bucket/data-import/diku/1234-test-name"),
+          containsString("/test-bucket/mod-data-import/data-import/diku/1234-test-name"),
           containsString("partNumber=5"),
           containsString("uploadId=upload-id-here")
         )


### PR DESCRIPTION
## Purpose
Added support for S3_SUB_PATH environment variable to enable better S3 bucket organization and path management.

## Approach

- Added S3_SUB_PATH environment variable with default value: mod-data-import
- Upgraded folio-s3-client version from 2.3.0 to 3.0.0
- Updated README.md
- Updated ModuleDescriptor-template.json

## Learning
https://folio-org.atlassian.net/browse/MODDATAIMP-1271