### PR TITLE
MODSOURMAN-1393: Update permission for getting locale settings

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -243,7 +243,7 @@
             "orders-storage.po-lines.item.post",
             "orders-storage.configuration.prefixes.collection.get",
             "orders-storage.configuration.suffixes.collection.get",
-            "configuration.entries.collection.get",
+            "locale.item.get",
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get",
             "isbn-utils.convert-to-13.get",


### PR DESCRIPTION
## Purpose
mod-configuration is deprecated, locale settings should be requested from mod-settings /locale API

## Approach
Update permission